### PR TITLE
EntityFactory allows fine-tuning of Gson

### DIFF
--- a/src/main/java/com/arangodb/entity/EntityFactory.java
+++ b/src/main/java/com/arangodb/entity/EntityFactory.java
@@ -40,7 +40,7 @@ public class EntityFactory {
   private static Gson gson;
   private static Gson gsonNull;
 
-  private static GsonBuilder getBuilder() {
+  public static GsonBuilder getGsonBuilder() {
     return new GsonBuilder()
       .addSerializationExclusionStrategy(new ExcludeExclusionStrategy(true))
       .addDeserializationExclusionStrategy(new ExcludeExclusionStrategy(false))
@@ -101,10 +101,32 @@ public class EntityFactory {
   }
 
   static {
-    gson = getBuilder().create();
-    gsonNull = getBuilder().serializeNulls().create();
+	  configure(getGsonBuilder());
   }
 
+  /**
+   * Configures instances of Gson used by this factory.
+   * 
+   * @param builders one or two GsonBuilder instances. If only one is provided it will be used for
+   *        initializing both <code>gson</code> and <code>gsonNull</code> fields (latter with
+   *        <code>serializeNulls()</code> called prior to creating). If two are given - first initializes <code>gson</code>
+   *        field, second initializes <code>gsonNull</code> (used when serialization of nulls is requested).
+   */
+  public static void configure(GsonBuilder ...builders) {
+	  if (builders.length < 1) {
+		  throw new IllegalArgumentException("builders");
+	  }
+
+	  gson = builders[0].create();
+	  
+	  if (builders.length > 1) {
+		  gsonNull = builders[1].create();
+	  } else {
+		  //use the first one again, but with nulls serialization turned on
+		  gsonNull = builders[0].serializeNulls().create();
+	  }
+  }
+  
   public static <T> T createEntity(String jsonText, Type type) {
     return gson.fromJson(jsonText, type);
   }

--- a/src/test/java/com/arangodb/TestInterface.java
+++ b/src/test/java/com/arangodb/TestInterface.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 tporadowski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb;
+
+/**
+ * @author tporadowski - tomasz at poradowski.com
+ */
+public interface TestInterface {
+	String getName();
+}

--- a/src/test/java/com/arangodb/TestInterfaceImpl.java
+++ b/src/test/java/com/arangodb/TestInterfaceImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 tporadowski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb;
+
+/**
+ * @author tporadowski - tomasz at poradowski.com
+ */
+public class TestInterfaceImpl implements TestInterface {
+	private String name;
+	
+	public TestInterfaceImpl(String name) {
+		this.name = name;
+	}
+	
+	@Override
+	public String getName() {
+		return name;
+	}
+
+}

--- a/src/test/java/com/arangodb/TestInterfaceInstanceCreator.java
+++ b/src/test/java/com/arangodb/TestInterfaceInstanceCreator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 tporadowski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.InstanceCreator;
+
+/**
+ * @author tporadowski - tomasz at poradowski.com
+ */
+public class TestInterfaceInstanceCreator implements
+		InstanceCreator<TestInterface> {
+
+	private int counter;
+	
+	@Override
+	public TestInterface createInstance(Type type) {
+		return new TestInterfaceImpl("name " + counter++);
+	}
+
+	/**
+	 * @return the counter
+	 */
+	public int getCounter() {
+		return counter;
+	}
+}


### PR DESCRIPTION
When playing around with classes generated by [Eclipse Modeling Framework](http://eclipse.org/modeling/emf/) I found that it was not possible to make use of factories generated by this tool when deserializing objects read from ArangoDB with `arangodb-java-driver`. This change exposes `EntityFactory.getGsonBuilder()` which may be further configured (i.e. with `InstanceCreator<T>`s, etc.) and then passed back to `EntityFactory.configure()` to be used by static methods of that class.