### PR TITLE
Possibility to CursorEntity to return Object instead of List<Object>

### DIFF
--- a/src/main/java/com/arangodb/NonUniqueResultException.java
+++ b/src/main/java/com/arangodb/NonUniqueResultException.java
@@ -1,0 +1,15 @@
+package com.arangodb;
+
+public class NonUniqueResultException extends RuntimeException {
+
+  /**
+   * Constructs a NonUniqueResultException.
+   *
+   * @param resultCount
+   *          The number of actual results.
+   */
+  public NonUniqueResultException(int resultCount) {
+    super("Query did not return a unique result: " + resultCount);
+  }
+
+}

--- a/src/main/java/com/arangodb/entity/CursorEntity.java
+++ b/src/main/java/com/arangodb/entity/CursorEntity.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import com.arangodb.NonUniqueResultException;
 import com.arangodb.util.CollectionUtils;
 
 /**
@@ -101,6 +102,13 @@ public class CursorEntity<T> extends BaseEntity implements Iterable<T> {
   
   public List<? extends T> getResults() {
     return results;
+  }
+  
+  public T getUniqueResult() {
+    int size = size();
+    if (size == 0) return null;
+    if (size > 1) throw new NonUniqueResultException(size);
+    return get(0);
   }
 
   public boolean isHasMore() {


### PR DESCRIPTION
Added method `getUniqueResult()` in class `CursorEntity`.
This method return `Object` if result of AQL query return one element.
Throw `NonUniqueResultException` if call method and size is greater than
one.