### PR TITLE
Function to execute AQL query and get the raw JSON response from Arango server

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -12,7 +12,11 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry including="**/*.java" kind="src" path="src/test/resources"/>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/src/main/java/com/arangodb/ArangoDriver.java
+++ b/src/main/java/com/arangodb/ArangoDriver.java
@@ -2474,7 +2474,7 @@ public class ArangoDriver extends BaseArangoDriver {
 	 * @param query an AQL query as string
 	 * @param bindVars a map containing all bind variables,
 	 * @param aqlQueryOptions AQL query options
-	 * @return
+	 * @return A JSON string with the results from server
 	 * @throws ArangoException
 	 */
 	public String executeAqlQueryJSON(

--- a/src/main/java/com/arangodb/ArangoDriver.java
+++ b/src/main/java/com/arangodb/ArangoDriver.java
@@ -75,6 +75,7 @@ import com.arangodb.entity.marker.VertexEntity;
 import com.arangodb.http.BatchHttpManager;
 import com.arangodb.http.BatchPart;
 import com.arangodb.http.HttpManager;
+import com.arangodb.http.HttpResponseEntity;
 import com.arangodb.http.InvocationHandlerImpl;
 import com.arangodb.impl.ImplFactory;
 import com.arangodb.impl.InternalBatchDriverImpl;
@@ -2468,6 +2469,27 @@ public class ArangoDriver extends BaseArangoDriver {
 
 		return cursorDriver.executeAqlQuery(getDefaultDatabase(), query, bindVars, aqlQueryOptions, clazz);
 	}
+
+	/**
+	 * Executes an AQL query and returns the raw JSON response
+	 * @param query an AQL query as string
+	 * @param bindVars a map containing all bind variables,
+	 * @param aqlQueryOptions AQL query options
+	 * @return
+	 * @throws ArangoException
+	 */
+	public HttpResponseEntity executeAqlQueryJSON(
+			String query,
+			Map<String, Object> bindVars,
+			AqlQueryOptions aqlQueryOptions
+			) throws ArangoException {
+
+			if (aqlQueryOptions == null) {
+				aqlQueryOptions = getDefaultAqlQueryOptions();
+			}
+
+			return cursorDriver.executeAqlQueryJSON(getDefaultDatabase(), query, bindVars, aqlQueryOptions);
+		}
 
 	/**
 	 * This method executes an AQL query and returns a DocumentCursorResult

--- a/src/main/java/com/arangodb/ArangoDriver.java
+++ b/src/main/java/com/arangodb/ArangoDriver.java
@@ -75,7 +75,6 @@ import com.arangodb.entity.marker.VertexEntity;
 import com.arangodb.http.BatchHttpManager;
 import com.arangodb.http.BatchPart;
 import com.arangodb.http.HttpManager;
-import com.arangodb.http.HttpResponseEntity;
 import com.arangodb.http.InvocationHandlerImpl;
 import com.arangodb.impl.ImplFactory;
 import com.arangodb.impl.InternalBatchDriverImpl;
@@ -2478,7 +2477,7 @@ public class ArangoDriver extends BaseArangoDriver {
 	 * @return
 	 * @throws ArangoException
 	 */
-	public HttpResponseEntity executeAqlQueryJSON(
+	public String executeAqlQueryJSON(
 			String query,
 			Map<String, Object> bindVars,
 			AqlQueryOptions aqlQueryOptions

--- a/src/main/java/com/arangodb/BaseArangoDriver.java
+++ b/src/main/java/com/arangodb/BaseArangoDriver.java
@@ -172,7 +172,7 @@ public abstract class BaseArangoDriver {
 	/**
 	 * Checks the Http response for database or server errors
 	 * @param res the response of the database
-	 * @return
+	 * @return The Http status code
 	 * @throws ArangoException if any error happened
 	 */
 	private int checkServerErrors(HttpResponseEntity res) throws ArangoException {

--- a/src/main/java/com/arangodb/InternalCursorDriver.java
+++ b/src/main/java/com/arangodb/InternalCursorDriver.java
@@ -8,6 +8,7 @@ import com.arangodb.entity.DocumentEntity;
 import com.arangodb.entity.QueriesResultEntity;
 import com.arangodb.entity.QueryTrackingPropertiesEntity;
 import com.arangodb.entity.ShortestPathEntity;
+import com.arangodb.http.HttpResponseEntity;
 import com.arangodb.impl.BaseDriverInterface;
 import com.arangodb.util.AqlQueryOptions;
 import com.arangodb.util.ShortestPathOptions;
@@ -39,6 +40,13 @@ public interface InternalCursorDriver extends BaseDriverInterface {
 		Map<String, Object> bindVars,
 		AqlQueryOptions aqlQueryOptions,
 		Class<T> clazz) throws ArangoException;
+
+	// return the raw JSON response from server
+	HttpResponseEntity executeAqlQueryJSON(
+			String database,
+			String query,
+			Map<String, Object> bindVars,
+			AqlQueryOptions aqlQueryOptions) throws ArangoException;
 
 	// request a cursor with DocumentEntity
 	<T, S extends DocumentEntity<T>> DocumentCursorResult<T, S> executeBaseCursorQuery(

--- a/src/main/java/com/arangodb/InternalCursorDriver.java
+++ b/src/main/java/com/arangodb/InternalCursorDriver.java
@@ -8,7 +8,6 @@ import com.arangodb.entity.DocumentEntity;
 import com.arangodb.entity.QueriesResultEntity;
 import com.arangodb.entity.QueryTrackingPropertiesEntity;
 import com.arangodb.entity.ShortestPathEntity;
-import com.arangodb.http.HttpResponseEntity;
 import com.arangodb.impl.BaseDriverInterface;
 import com.arangodb.util.AqlQueryOptions;
 import com.arangodb.util.ShortestPathOptions;
@@ -42,7 +41,7 @@ public interface InternalCursorDriver extends BaseDriverInterface {
 		Class<T> clazz) throws ArangoException;
 
 	// return the raw JSON response from server
-	HttpResponseEntity executeAqlQueryJSON(
+	String executeAqlQueryJSON(
 			String database,
 			String query,
 			Map<String, Object> bindVars,

--- a/src/main/java/com/arangodb/impl/InternalCursorDriverImpl.java
+++ b/src/main/java/com/arangodb/impl/InternalCursorDriverImpl.java
@@ -54,6 +54,16 @@ public class InternalCursorDriverImpl extends BaseArangoDriverImpl implements co
 		return createEntity(res, CursorEntity.class);
 	}
 
+	@Override
+	public HttpResponseEntity executeAqlQueryJSON(
+			String database,
+			String query,
+			Map<String, Object> bindVars,
+			AqlQueryOptions aqlQueryOptions) throws ArangoException {
+
+			return getCursor(database, query, bindVars, aqlQueryOptions);
+		}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> CursorEntity<T> executeCursorEntityQuery(

--- a/src/main/java/com/arangodb/impl/InternalCursorDriverImpl.java
+++ b/src/main/java/com/arangodb/impl/InternalCursorDriverImpl.java
@@ -55,13 +55,13 @@ public class InternalCursorDriverImpl extends BaseArangoDriverImpl implements co
 	}
 
 	@Override
-	public HttpResponseEntity executeAqlQueryJSON(
+	public String executeAqlQueryJSON(
 			String database,
 			String query,
 			Map<String, Object> bindVars,
 			AqlQueryOptions aqlQueryOptions) throws ArangoException {
 
-			return getCursor(database, query, bindVars, aqlQueryOptions);
+			return getJSONResponseText(getCursor(database, query, bindVars, aqlQueryOptions));
 		}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Exceptions are thrown on server errors, just like the regular AQL query. Only the JSON with the results is returned, as a string. Results are not interpreted into java objects (so any arbitrary JSON doc can be returned by the query), but are parsed, hence validated, as part of the process.
