### PR TITLE
Batch driver performance fix

### DIFF
--- a/src/main/java/com/arangodb/impl/InternalBatchDriverImpl.java
+++ b/src/main/java/com/arangodb/impl/InternalBatchDriverImpl.java
@@ -51,26 +51,26 @@ public class InternalBatchDriverImpl extends BaseArangoDriverImpl {
 
 	public DefaultEntity executeBatch(List<BatchPart> callStack, String defaultDataBase) throws ArangoException {
 
-		String body = "";
+		StringBuilder body = new StringBuilder();
 
 		Map<String, InvocationObject> resolver = new HashMap<String, InvocationObject>();
 
 		for (BatchPart bp : callStack) {
-			body += "--" + delimiter + newline;
-			body += "Content-Type: application/x-arango-batchpart" + newline;
-			body += "Content-Id: " + bp.getId() + newline + newline;
-			body += bp.getMethod() + " " + bp.getUrl() + " " + "HTTP/1.1" + newline;
-			body += "Host: " + this.configure.getArangoHost().getHost() + newline + newline;
-			body += bp.getBody() == null ? "" : bp.getBody() + newline + newline;
+			body.append("--").append(delimiter).append(newline);
+			body.append("Content-Type: application/x-arango-batchpart").append(newline);
+			body.append("Content-Id: ").append(bp.getId()).append(newline).append(newline);
+			body.append(bp.getMethod()).append(" ").append(bp.getUrl()).append(" ").append("HTTP/1.1").append(newline);
+			body.append("Host: ").append(this.configure.getArangoHost().getHost()).append(newline).append(newline);
+			body.append(bp.getBody() == null ? "" : bp.getBody()).append(newline).append(newline);
 			resolver.put(bp.getId(), bp.getInvocationObject());
 		}
-		body += "--" + delimiter + "--";
+		body.append("--").append(delimiter).append("--");
 
 		Map<String, Object> headers = new HashMap<String, Object>();
 		headers.put("Content-Type", "multipart/form-data; boundary=" + delimiter);
 
 		HttpResponseEntity res = httpManager.doPostWithHeaders(createEndpointUrl(defaultDataBase, "/_api/batch"), null,
-			null, headers, body);
+			null, headers, body.toString());
 
 		String data = res.getText();
 		res.setContentType("application/json");


### PR DESCRIPTION
I fix performance issue in batch driver. I try to run several thousand operations in one batch request, but there will never be send to server before my fix. It's because String concatenation within loop. After fix, i run very large batch queries without problem. 

Where you're concatenating in a loop - that's usually when the compiler can't substitute StringBuilder by itself.