### PR TITLE
fixes #63; better toString representation of ArangoHost

### DIFF
--- a/src/main/java/com/arangodb/ArangoHost.java
+++ b/src/main/java/com/arangodb/ArangoHost.java
@@ -61,4 +61,20 @@ public class ArangoHost {
 		return true;
 	}
 
+	/**
+	 * Returns a string representation in the form <code>host:port</code>,
+	 * adding square brackets if needed
+	 */
+	@Override
+	public String toString() {
+	    // "[]:12345" requires 8 extra bytes.
+	    StringBuilder builder = new StringBuilder(host.length() + 8);
+	    if (host.indexOf(':') >= 0) {
+	      builder.append('[').append(host).append(']');
+	    } else {
+	      builder.append(host);
+	    }
+	    builder.append(':').append(port);
+	    return builder.toString();
+	}
 }

--- a/src/test/java/com/arangodb/ArangoHostTest.java
+++ b/src/test/java/com/arangodb/ArangoHostTest.java
@@ -1,0 +1,25 @@
+package com.arangodb;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * @author Anton Sarov - initial contribution
+ *
+ */
+public class ArangoHostTest {
+
+	@Test
+	public void testToString() {
+		ArangoHost arangoHost = new ArangoHost("127.0.0.1", 8529);
+		assertThat(arangoHost.toString(), is("127.0.0.1:8529"));
+	}
+	
+	@Test
+	public void testToStringIPv6() {
+		ArangoHost arangoHost = new ArangoHost("2001:db8:1f70::999:de8:7648:6e8", 8529);
+		assertThat(arangoHost.toString(), is("[2001:db8:1f70::999:de8:7648:6e8]:8529"));
+	}
+}


### PR DESCRIPTION
fixes #63; better toString representation of ArangoHost in the form "host:port" - considering IPv4 and IPv6. Unit tests included.
