### PR TITLE
Support serializing collections with null elements and extended collections

### DIFF
--- a/src/main/java/com/arangodb/velocypack/VPack.java
+++ b/src/main/java/com/arangodb/velocypack/VPack.java
@@ -652,7 +652,7 @@ public class VPack {
 		builder.add(name, ValueType.ARRAY);
 		for (final Iterator iterator = Iterable.class.cast(value).iterator(); iterator.hasNext();) {
 			final Object element = iterator.next();
-			addValue(null, element.getClass(), element, builder, null, additionalFields);
+			addValue(null, element != null ? element.getClass() : null, element, builder, null, additionalFields);
 		}
 		builder.close();
 	}

--- a/src/main/java/com/arangodb/velocypack/internal/VPackCache.java
+++ b/src/main/java/com/arangodb/velocypack/internal/VPackCache.java
@@ -187,7 +187,7 @@ public class VPackCache {
 		final Class<?> clazz = field.getType();
 		final Type type;
 		if (Collection.class.isAssignableFrom(clazz) || Map.class.isAssignableFrom(clazz)) {
-			type = (ParameterizedType) field.getGenericType();
+			type = field.getGenericType();
 		} else {
 			type = clazz;
 		}


### PR DESCRIPTION
There are two scenarios that are not yet supported in VPack serialization:

1. Serializing classes that extend collections yet are not themselves generic.
1. Serializing collections that contain null elements.

The first item is solved by removing an explicit yet unnecessary cast to ParameterizedType in com.arangodb.velocypack.internal.VPackCache#createFieldInfo.

The second can be addressed by handling null elements while serializing collection contents.
