### PR TITLE
Support byte and Byte serialization and deserialization by default.

### DIFF
--- a/src/main/java/com/arangodb/velocypack/VPack.java
+++ b/src/main/java/com/arangodb/velocypack/VPack.java
@@ -126,6 +126,8 @@ public class VPack {
 			serializers.put(VPackSlice.class, VPackSerializers.VPACK);
 			serializers.put(UUID.class, VPackSerializers.UUID);
 			serializers.put(new byte[] {}.getClass(), VPackSerializers.BYTE_ARRAY);
+			serializers.put(Byte.class, VPackSerializers.BYTE);
+			serializers.put(byte.class, VPackSerializers.BYTE);
 
 			deserializers.put(String.class, VPackDeserializers.STRING);
 			deserializers.put(Boolean.class, VPackDeserializers.BOOLEAN);
@@ -151,6 +153,8 @@ public class VPack {
 			deserializers.put(VPackSlice.class, VPackDeserializers.VPACK);
 			deserializers.put(UUID.class, VPackDeserializers.UUID);
 			deserializers.put(new byte[] {}.getClass(), VPackDeserializers.BYTE_ARRAY);
+			deserializers.put(Byte.class, VPackDeserializers.BYTE);
+			deserializers.put(byte.class, VPackDeserializers.BYTE);
 
 			annotationFieldFilter.put(Expose.class, new VPackAnnotationFieldFilter<Expose>() {
 				@Override

--- a/src/main/java/com/arangodb/velocypack/VPackBuilder.java
+++ b/src/main/java/com/arangodb/velocypack/VPackBuilder.java
@@ -152,6 +152,17 @@ public class VPackBuilder {
 			}
 		}
 	};
+	private static final Appender<Byte> BYTE = new Appender<Byte>() {
+		@Override
+		public void append(final VPackBuilder builder, final Byte value) {
+			if (value <= 9 && value >= -6) {
+				builder.appendSmallInt(value);
+			} else {
+				builder.add((byte) 0x23);
+				builder.append(value, INTEGER_BYTES);
+			}
+		}
+	};
 	private static final Appender<BigInteger> BIG_INTEGER = new Appender<BigInteger>() {
 		@Override
 		public void append(final VPackBuilder builder, final BigInteger value) throws VPackBuilderException {
@@ -379,6 +390,10 @@ public class VPackBuilder {
 
 	public VPackBuilder add(final String attribute, final Short value) throws VPackBuilderException {
 		return addInternal(attribute, SHORT, value);
+	}
+
+	public VPackBuilder add(final String attribute, final Byte value) throws VPackBuilderException {
+		return addInternal(attribute, BYTE, value);
 	}
 
 	public VPackBuilder add(final String attribute, final BigInteger value) throws VPackBuilderException {

--- a/src/main/java/com/arangodb/velocypack/VPackSlice.java
+++ b/src/main/java/com/arangodb/velocypack/VPackSlice.java
@@ -253,6 +253,10 @@ public class VPackSlice implements Serializable {
 		return getAsNumber().shortValue();
 	}
 
+	public byte getAsByte() {
+		return getAsNumber().byteValue();
+	}
+
 	public BigInteger getAsBigInteger() {
 		if (isSmallInt() || isInt()) {
 			return BigInteger.valueOf(getAsLong());

--- a/src/main/java/com/arangodb/velocypack/internal/VPackDeserializers.java
+++ b/src/main/java/com/arangodb/velocypack/internal/VPackDeserializers.java
@@ -231,5 +231,14 @@ public class VPackDeserializers {
 		}
 
 	};
+	public static final VPackDeserializer<Byte> BYTE = new VPackDeserializer<Byte>() {
+		@Override
+		public Byte deserialize(
+				final VPackSlice parent,
+				final VPackSlice vpack,
+				final VPackDeserializationContext context) {
+			return vpack.getAsByte();
+		}
+	};
 
 }

--- a/src/main/java/com/arangodb/velocypack/internal/VPackSerializers.java
+++ b/src/main/java/com/arangodb/velocypack/internal/VPackSerializers.java
@@ -215,4 +215,14 @@ public class VPackSerializers {
 			builder.add(attribute, DatatypeConverter.printBase64Binary(value));
 		}
 	};
+	public static final VPackSerializer<Byte> BYTE = new VPackSerializer<Byte>() {
+		@Override
+		public void serialize(
+				final VPackBuilder builder,
+				final String attribute,
+				final Byte value,
+				final VPackSerializationContext context) {
+			builder.add(attribute, value);
+		}
+	};
 }

--- a/src/test/java/com/arangodb/velocypack/VPackSerializeDeserializeTest.java
+++ b/src/test/java/com/arangodb/velocypack/VPackSerializeDeserializeTest.java
@@ -438,6 +438,61 @@ public class VPackSerializeDeserializeTest {
 		assertThat(entity.s2, is(new Short((short) 3)));
 	}
 
+
+	protected static class TestEntityByte {
+		private byte b1 = 1; // short integer path
+		private Byte b2 = 100; // integer path
+
+		public byte getB1() {
+			return b1;
+		}
+
+		public void setB1(final byte b1) {
+			this.b1 = b1;
+		}
+
+		public Byte getB2() {
+			return b2;
+		}
+
+		public void setB2(final Byte b2) {
+			this.b2 = b2;
+		}
+	}
+
+	@Test
+	public void fromByte() throws VPackException {
+		final VPackSlice vpack = new VPack.Builder().build().serialize(new TestEntityByte());
+		assertThat(vpack, is(notNullValue()));
+		assertThat(vpack.isObject(), is(true));
+		{
+			final VPackSlice b1 = vpack.get("b1");
+			assertThat(b1.isInteger(), is(true));
+			assertThat(b1.getAsByte(), is((byte) 1));
+		}
+		{
+			final VPackSlice b2 = vpack.get("b2");
+			assertThat(b2.isInteger(), is(true));
+			assertThat(b2.getAsByte(), is((byte) 100));
+		}
+	}
+
+	@Test
+	public void toByte() throws VPackException {
+		final VPackBuilder builder = new VPackBuilder();
+		{
+			builder.add(ValueType.OBJECT);
+			builder.add("b1", 30); // integer path
+			builder.add("b2", 4); // short integer path
+			builder.close();
+		}
+		final VPackSlice vpack = builder.slice();
+		final TestEntityByte entity = new VPack.Builder().build().deserialize(vpack, TestEntityByte.class);
+		assertThat(entity, is(notNullValue()));
+		assertThat(entity.b1, is((byte) 30));
+		assertThat(entity.b2, is(new Byte((byte) 4)));
+	}
+
 	protected static class TestEntityDouble {
 		private Double d1 = 1.5;
 		private double d2 = 1.5;


### PR DESCRIPTION
The current version of the ArangoDB Java driver does not support serialization of objects with attributes of type byte or java.lang.Byte.

Added default serializer, deserializer and appender for byte types.
