### PR TITLE
Issue #125 Adding exception field to ErrorEntity to match response re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,6 @@
 	<organization>
 		<name>ArangoDB GmbH</name>
 		<url>https://www.arangodb.com</url>
-	</organization>
-	
+	</organization>	
+
 </project>

--- a/src/main/java/com/arangodb/ArangoDB.java
+++ b/src/main/java/com/arangodb/ArangoDB.java
@@ -57,7 +57,7 @@ import com.arangodb.model.UserCreateOptions;
 import com.arangodb.model.UserUpdateOptions;
 import com.arangodb.util.ArangoDeserializer;
 import com.arangodb.util.ArangoSerializer;
-import com.arangodb.util.ArangoUtil;
+import com.arangodb.util.ArangoSerialization;
 import com.arangodb.velocypack.VPack;
 import com.arangodb.velocypack.VPackAnnotationFieldFilter;
 import com.arangodb.velocypack.VPackAnnotationFieldNaming;
@@ -345,10 +345,10 @@ public class ArangoDB extends InternalArangoDB<ArangoExecutorSync, Response, Con
 
 	}
 
-	public ArangoDB(final CommunicationSync.Builder commBuilder, final ArangoUtil util,
+	public ArangoDB(final CommunicationSync.Builder commBuilder, final ArangoSerialization util,
 		final CollectionCache collectionCache) {
 		super(new ArangoExecutorSync(commBuilder.build(util, collectionCache), util, new DocumentCache(),
-				collectionCache));
+				collectionCache), util);
 		final Communication<Response, ConnectionSync> cacheCom = commBuilder.build(util, collectionCache);
 		collectionCache.init(new DBAccess() {
 			@Override

--- a/src/main/java/com/arangodb/ArangoDBException.java
+++ b/src/main/java/com/arangodb/ArangoDBException.java
@@ -49,6 +49,10 @@ public class ArangoDBException extends RuntimeException {
 		return entity != null ? entity.getErrorMessage() : null;
 	}
 
+	public String getException() {
+		return entity != null ? entity.getException() : null;
+	}
+
 	public int getResponseCode() {
 		return entity != null ? entity.getCode() : null;
 	}

--- a/src/main/java/com/arangodb/ArangoDatabase.java
+++ b/src/main/java/com/arangodb/ArangoDatabase.java
@@ -55,7 +55,7 @@ import com.arangodb.model.DocumentReadOptions;
 import com.arangodb.model.GraphCreateOptions;
 import com.arangodb.model.TransactionOptions;
 import com.arangodb.model.TraversalOptions;
-import com.arangodb.util.ArangoUtil;
+import com.arangodb.util.ArangoSerialization;
 import com.arangodb.velocypack.Type;
 import com.arangodb.velocystream.Request;
 import com.arangodb.velocystream.Response;
@@ -67,12 +67,12 @@ import com.arangodb.velocystream.Response;
 public class ArangoDatabase extends InternalArangoDatabase<ArangoDB, ArangoExecutorSync, Response, ConnectionSync> {
 
 	protected ArangoDatabase(final ArangoDB arangoDB, final String name) {
-		super(arangoDB, arangoDB.executor(), name);
+		super(arangoDB, arangoDB.executor(), arangoDB.util(), name);
 	}
 
-	protected ArangoDatabase(final Communication<Response, ConnectionSync> communication, final ArangoUtil util,
+	protected ArangoDatabase(final Communication<Response, ConnectionSync> communication, final ArangoSerialization util,
 		final DocumentCache documentCache, final CollectionCache collectionCache, final String name) {
-		super(null, new ArangoExecutorSync(communication, util, documentCache, collectionCache), name);
+		super(null, new ArangoExecutorSync(communication, util, documentCache, collectionCache), util, name);
 	}
 
 	/**

--- a/src/main/java/com/arangodb/entity/ArangoDBVersion.java
+++ b/src/main/java/com/arangodb/entity/ArangoDBVersion.java
@@ -28,8 +28,13 @@ package com.arangodb.entity;
  */
 public class ArangoDBVersion {
 
+	public enum License {
+		ENTERPRISE, COMMUNITY
+	}
+
 	private String server;
 	private String version;
+	private License license;
 
 	public ArangoDBVersion() {
 		super();
@@ -48,6 +53,13 @@ public class ArangoDBVersion {
 	 */
 	public String getVersion() {
 		return version;
+	}
+
+	/**
+	 * @return the license
+	 */
+	public License getLicense() {
+		return license;
 	}
 
 }

--- a/src/main/java/com/arangodb/entity/ErrorEntity.java
+++ b/src/main/java/com/arangodb/entity/ErrorEntity.java
@@ -27,6 +27,7 @@ package com.arangodb.entity;
 public class ErrorEntity {
 
 	private String errorMessage;
+	private String exception;
 	private int code;
 	private int errorNum;
 
@@ -39,6 +40,13 @@ public class ErrorEntity {
 	 */
 	public String getErrorMessage() {
 		return errorMessage;
+	}
+
+	/**
+	 * @return the exception message, passed when transaction fails
+	 */
+	public String getException() {
+		return exception;
 	}
 
 	/**

--- a/src/main/java/com/arangodb/internal/ArangoCursorIterator.java
+++ b/src/main/java/com/arangodb/internal/ArangoCursorIterator.java
@@ -68,7 +68,7 @@ public class ArangoCursorIterator<T> implements Iterator<T> {
 		if (!hasNext()) {
 			throw new NoSuchElementException();
 		}
-		return db.executor.deserialize(result.getResult().get(pos++), cursor.getType());
+		return db.util().deserialize(result.getResult().get(pos++), cursor.getType());
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/internal/ArangoExecuteable.java
+++ b/src/main/java/com/arangodb/internal/ArangoExecuteable.java
@@ -21,7 +21,7 @@
 package com.arangodb.internal;
 
 import com.arangodb.internal.velocystream.Connection;
-import com.arangodb.util.ArangoUtil;
+import com.arangodb.util.ArangoSerialization;
 
 /**
  * @author Mark - mark at arangodb.com
@@ -30,17 +30,19 @@ import com.arangodb.util.ArangoUtil;
 public abstract class ArangoExecuteable<E extends ArangoExecutor<R, C>, R, C extends Connection> {
 
 	protected final E executor;
+	private final ArangoSerialization util;
 
-	public ArangoExecuteable(final E executor) {
+	public ArangoExecuteable(final E executor, final ArangoSerialization util) {
 		super();
 		this.executor = executor;
+		this.util = util;
 	}
 
 	protected E executor() {
 		return executor;
 	}
 
-	public ArangoUtil util() {
-		return executor.util();
+	public ArangoSerialization util() {
+		return util;
 	}
 }

--- a/src/main/java/com/arangodb/internal/ArangoExecutor.java
+++ b/src/main/java/com/arangodb/internal/ArangoExecutor.java
@@ -29,7 +29,8 @@ import java.util.regex.Pattern;
 import com.arangodb.ArangoDBException;
 import com.arangodb.internal.velocystream.Communication;
 import com.arangodb.internal.velocystream.Connection;
-import com.arangodb.util.ArangoUtil;
+import com.arangodb.util.ArangoSerializer;
+import com.arangodb.util.ArangoSerialization;
 import com.arangodb.velocypack.VPackSlice;
 import com.arangodb.velocypack.exception.VPackException;
 import com.arangodb.velocystream.Response;
@@ -52,9 +53,9 @@ public abstract class ArangoExecutor<R, C extends Connection> {
 	private final Communication<R, C> communication;
 	private final DocumentCache documentCache;
 	private final CollectionCache collectionCache;
-	private final ArangoUtil util;
+	private final ArangoSerialization util;
 
-	protected ArangoExecutor(final Communication<R, C> communication, final ArangoUtil util,
+	protected ArangoExecutor(final Communication<R, C> communication, final ArangoSerialization util,
 		final DocumentCache documentCache, final CollectionCache collectionCache) {
 		super();
 		this.communication = communication;
@@ -75,7 +76,7 @@ public abstract class ArangoExecutor<R, C extends Connection> {
 		return collectionCache;
 	}
 
-	protected ArangoUtil util() {
+	protected ArangoSerialization util() {
 		return util;
 	}
 
@@ -134,30 +135,37 @@ public abstract class ArangoExecutor<R, C extends Connection> {
 		return (T) ((type != Void.class && response.getBody() != null) ? deserialize(response.getBody(), type) : null);
 	}
 
+	@Deprecated
 	protected <T> T deserialize(final VPackSlice vpack, final Type type) throws ArangoDBException {
 		return util.deserialize(vpack, type);
 	}
 
+	@Deprecated
 	protected VPackSlice serialize(final Object entity) throws ArangoDBException {
 		return util.serialize(entity);
 	}
 
+	@Deprecated
 	protected VPackSlice serialize(final Object entity, final boolean serializeNullValues) throws ArangoDBException {
-		return util.serialize(entity, serializeNullValues);
+		return util.serialize(entity, new ArangoSerializer.Options().serializeNullValues(serializeNullValues));
 	}
 
+	@Deprecated
 	protected VPackSlice serialize(final Object entity, final Type type) throws ArangoDBException {
-		return util.serialize(entity, type);
+		return util.serialize(entity, new ArangoSerializer.Options().type(type));
 	}
 
+	@Deprecated
 	protected VPackSlice serialize(final Object entity, final Type type, final boolean serializeNullValues)
 			throws ArangoDBException {
-		return util.serialize(entity, type, serializeNullValues);
+		return util.serialize(entity,
+			new ArangoSerializer.Options().type(type).serializeNullValues(serializeNullValues));
 	}
 
+	@Deprecated
 	protected VPackSlice serialize(final Object entity, final Type type, final Map<String, Object> additionalFields)
 			throws ArangoDBException {
-		return util.serialize(entity, type, additionalFields);
+		return util.serialize(entity, new ArangoSerializer.Options().type(type).additionalFields(additionalFields));
 	}
 
 }

--- a/src/main/java/com/arangodb/internal/ArangoExecutorSync.java
+++ b/src/main/java/com/arangodb/internal/ArangoExecutorSync.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Type;
 import com.arangodb.ArangoDBException;
 import com.arangodb.internal.velocystream.Communication;
 import com.arangodb.internal.velocystream.ConnectionSync;
-import com.arangodb.util.ArangoUtil;
+import com.arangodb.util.ArangoSerialization;
 import com.arangodb.velocypack.exception.VPackException;
 import com.arangodb.velocystream.Request;
 import com.arangodb.velocystream.Response;
@@ -36,7 +36,7 @@ import com.arangodb.velocystream.Response;
  */
 public class ArangoExecutorSync extends ArangoExecutor<Response, ConnectionSync> {
 
-	public ArangoExecutorSync(final Communication<Response, ConnectionSync> communication, final ArangoUtil util,
+	public ArangoExecutorSync(final Communication<Response, ConnectionSync> communication, final ArangoSerialization util,
 		final DocumentCache documentCache, final CollectionCache collectionCache) {
 		super(communication, util, documentCache, collectionCache);
 	}

--- a/src/main/java/com/arangodb/internal/InternalArangoDB.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoDB.java
@@ -38,6 +38,7 @@ import com.arangodb.model.LogOptions;
 import com.arangodb.model.OptionsBuilder;
 import com.arangodb.model.UserCreateOptions;
 import com.arangodb.model.UserUpdateOptions;
+import com.arangodb.util.ArangoSerialization;
 import com.arangodb.velocypack.Type;
 import com.arangodb.velocypack.VPackSlice;
 import com.arangodb.velocypack.exception.VPackException;
@@ -65,8 +66,8 @@ public class InternalArangoDB<E extends ArangoExecutor<R, C>, R, C extends Conne
 	private static final String PROPERTY_KEY_MAX_CONNECTIONS = "arangodb.connections.max";
 	protected static final String DEFAULT_PROPERTY_FILE = "/arangodb.properties";
 
-	public InternalArangoDB(final E executor) {
-		super(executor);
+	public InternalArangoDB(final E executor, final ArangoSerialization util) {
+		super(executor, util);
 	}
 
 	protected static void loadHosts(final Properties properties, final Collection<Host> hosts) {
@@ -148,7 +149,7 @@ public class InternalArangoDB<E extends ArangoExecutor<R, C>, R, C extends Conne
 	protected Request createDatabaseRequest(final String name) {
 		final Request request = new Request(ArangoDBConstants.SYSTEM, RequestType.POST,
 				ArangoDBConstants.PATH_API_DATABASE);
-		request.setBody(executor.serialize(OptionsBuilder.build(new DBCreateOptions(), name)));
+		request.setBody(util().serialize(OptionsBuilder.build(new DBCreateOptions(), name)));
 		return request;
 	}
 
@@ -170,7 +171,7 @@ public class InternalArangoDB<E extends ArangoExecutor<R, C>, R, C extends Conne
 			@Override
 			public Collection<String> deserialize(final Response response) throws VPackException {
 				final VPackSlice result = response.getBody().get(ArangoDBConstants.RESULT);
-				return executor.deserialize(result, new Type<Collection<String>>() {
+				return util().deserialize(result, new Type<Collection<String>>() {
 				}.getType());
 			}
 		};
@@ -203,8 +204,8 @@ public class InternalArangoDB<E extends ArangoExecutor<R, C>, R, C extends Conne
 		final UserCreateOptions options) {
 		final Request request;
 		request = new Request(database, RequestType.POST, ArangoDBConstants.PATH_API_USER);
-		request.setBody(executor
-				.serialize(OptionsBuilder.build(options != null ? options : new UserCreateOptions(), user, passwd)));
+		request.setBody(
+			util().serialize(OptionsBuilder.build(options != null ? options : new UserCreateOptions(), user, passwd)));
 		return request;
 	}
 
@@ -225,7 +226,7 @@ public class InternalArangoDB<E extends ArangoExecutor<R, C>, R, C extends Conne
 			@Override
 			public Collection<UserEntity> deserialize(final Response response) throws VPackException {
 				final VPackSlice result = response.getBody().get(ArangoDBConstants.RESULT);
-				return executor.deserialize(result, new Type<Collection<UserEntity>>() {
+				return util().deserialize(result, new Type<Collection<UserEntity>>() {
 				}.getType());
 			}
 		};
@@ -234,14 +235,14 @@ public class InternalArangoDB<E extends ArangoExecutor<R, C>, R, C extends Conne
 	protected Request updateUserRequest(final String database, final String user, final UserUpdateOptions options) {
 		final Request request;
 		request = new Request(database, RequestType.PATCH, executor.createPath(ArangoDBConstants.PATH_API_USER, user));
-		request.setBody(executor.serialize(options != null ? options : new UserUpdateOptions()));
+		request.setBody(util().serialize(options != null ? options : new UserUpdateOptions()));
 		return request;
 	}
 
 	protected Request replaceUserRequest(final String database, final String user, final UserUpdateOptions options) {
 		final Request request;
 		request = new Request(database, RequestType.PUT, executor.createPath(ArangoDBConstants.PATH_API_USER, user));
-		request.setBody(executor.serialize(options != null ? options : new UserUpdateOptions()));
+		request.setBody(util().serialize(options != null ? options : new UserUpdateOptions()));
 		return request;
 	}
 
@@ -263,7 +264,7 @@ public class InternalArangoDB<E extends ArangoExecutor<R, C>, R, C extends Conne
 
 	protected Request setLogLevelRequest(final LogLevelEntity entity) {
 		return new Request(ArangoDBConstants.SYSTEM, RequestType.PUT, ArangoDBConstants.PATH_API_ADMIN_LOG_LEVEL)
-				.setBody(executor.serialize(entity));
+				.setBody(util().serialize(entity));
 	}
 
 }

--- a/src/main/java/com/arangodb/internal/InternalArangoEdgeCollection.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoEdgeCollection.java
@@ -33,6 +33,7 @@ import com.arangodb.model.EdgeCreateOptions;
 import com.arangodb.model.EdgeDeleteOptions;
 import com.arangodb.model.EdgeReplaceOptions;
 import com.arangodb.model.EdgeUpdateOptions;
+import com.arangodb.util.ArangoSerializer;
 import com.arangodb.velocypack.VPackSlice;
 import com.arangodb.velocypack.exception.VPackException;
 import com.arangodb.velocystream.Request;
@@ -50,7 +51,7 @@ public class InternalArangoEdgeCollection<A extends InternalArangoDB<E, R, C>, D
 	private final String name;
 
 	public InternalArangoEdgeCollection(final G graph, final String name) {
-		super(graph.executor());
+		super(graph.executor(), graph.util());
 		this.graph = graph;
 		this.name = name;
 	}
@@ -68,7 +69,7 @@ public class InternalArangoEdgeCollection<A extends InternalArangoDB<E, R, C>, D
 				executor.createPath(ArangoDBConstants.PATH_API_GHARIAL, graph.name(), ArangoDBConstants.EDGE, name));
 		final EdgeCreateOptions params = (options != null ? options : new EdgeCreateOptions());
 		request.putQueryParam(ArangoDBConstants.WAIT_FOR_SYNC, params.getWaitForSync());
-		request.setBody(executor.serialize(value));
+		request.setBody(util().serialize(value));
 		return request;
 	}
 
@@ -77,7 +78,7 @@ public class InternalArangoEdgeCollection<A extends InternalArangoDB<E, R, C>, D
 			@Override
 			public EdgeEntity deserialize(final Response response) throws VPackException {
 				final VPackSlice body = response.getBody().get(ArangoDBConstants.EDGE);
-				final EdgeEntity doc = executor.deserialize(body, EdgeEntity.class);
+				final EdgeEntity doc = util().deserialize(body, EdgeEntity.class);
 				final Map<DocumentField.Type, String> values = new HashMap<DocumentField.Type, String>();
 				values.put(DocumentField.Type.ID, doc.getId());
 				values.put(DocumentField.Type.KEY, doc.getKey());
@@ -102,7 +103,7 @@ public class InternalArangoEdgeCollection<A extends InternalArangoDB<E, R, C>, D
 		return new ResponseDeserializer<T>() {
 			@Override
 			public T deserialize(final Response response) throws VPackException {
-				return executor.deserialize(response.getBody().get(ArangoDBConstants.EDGE), type);
+				return util().deserialize(response.getBody().get(ArangoDBConstants.EDGE), type);
 			}
 		};
 	}
@@ -114,7 +115,7 @@ public class InternalArangoEdgeCollection<A extends InternalArangoDB<E, R, C>, D
 		final EdgeReplaceOptions params = (options != null ? options : new EdgeReplaceOptions());
 		request.putQueryParam(ArangoDBConstants.WAIT_FOR_SYNC, params.getWaitForSync());
 		request.putHeaderParam(ArangoDBConstants.IF_MATCH, params.getIfMatch());
-		request.setBody(executor.serialize(value));
+		request.setBody(util().serialize(value));
 		return request;
 	}
 
@@ -123,7 +124,7 @@ public class InternalArangoEdgeCollection<A extends InternalArangoDB<E, R, C>, D
 			@Override
 			public EdgeUpdateEntity deserialize(final Response response) throws VPackException {
 				final VPackSlice body = response.getBody().get(ArangoDBConstants.EDGE);
-				final EdgeUpdateEntity doc = executor.deserialize(body, EdgeUpdateEntity.class);
+				final EdgeUpdateEntity doc = util().deserialize(body, EdgeUpdateEntity.class);
 				final Map<DocumentField.Type, String> values = new HashMap<DocumentField.Type, String>();
 				values.put(DocumentField.Type.REV, doc.getRev());
 				executor.documentCache().setValues(value, values);
@@ -141,7 +142,7 @@ public class InternalArangoEdgeCollection<A extends InternalArangoDB<E, R, C>, D
 		request.putQueryParam(ArangoDBConstants.KEEP_NULL, params.getKeepNull());
 		request.putQueryParam(ArangoDBConstants.WAIT_FOR_SYNC, params.getWaitForSync());
 		request.putHeaderParam(ArangoDBConstants.IF_MATCH, params.getIfMatch());
-		request.setBody(executor.serialize(value, true));
+		request.setBody(util().serialize(value, new ArangoSerializer.Options().serializeNullValues(true)));
 		return request;
 	}
 
@@ -150,7 +151,7 @@ public class InternalArangoEdgeCollection<A extends InternalArangoDB<E, R, C>, D
 			@Override
 			public EdgeUpdateEntity deserialize(final Response response) throws VPackException {
 				final VPackSlice body = response.getBody().get(ArangoDBConstants.EDGE);
-				return executor.deserialize(body, EdgeUpdateEntity.class);
+				return util().deserialize(body, EdgeUpdateEntity.class);
 			}
 		};
 	}

--- a/src/main/java/com/arangodb/internal/InternalArangoGraph.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoGraph.java
@@ -45,7 +45,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 	private final String name;
 
 	public InternalArangoGraph(final D db, final String name) {
-		super(db.executor());
+		super(db.executor(), db.util());
 		this.db = db;
 		this.name = name;
 	}
@@ -80,7 +80,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 		return new ResponseDeserializer<Collection<String>>() {
 			@Override
 			public Collection<String> deserialize(final Response response) throws VPackException {
-				return executor.deserialize(response.getBody().get(ArangoDBConstants.COLLECTIONS),
+				return util().deserialize(response.getBody().get(ArangoDBConstants.COLLECTIONS),
 					new Type<Collection<String>>() {
 					}.getType());
 			}
@@ -90,7 +90,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 	protected Request addVertexCollectionRequest(final String name) {
 		final Request request = new Request(db.name(), RequestType.POST,
 				executor.createPath(ArangoDBConstants.PATH_API_GHARIAL, name(), ArangoDBConstants.VERTEX));
-		request.setBody(executor.serialize(OptionsBuilder.build(new VertexCollectionCreateOptions(), name)));
+		request.setBody(util().serialize(OptionsBuilder.build(new VertexCollectionCreateOptions(), name)));
 		return request;
 	}
 
@@ -107,7 +107,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 		return new ResponseDeserializer<Collection<String>>() {
 			@Override
 			public Collection<String> deserialize(final Response response) throws VPackException {
-				return executor.deserialize(response.getBody().get(ArangoDBConstants.COLLECTIONS),
+				return util().deserialize(response.getBody().get(ArangoDBConstants.COLLECTIONS),
 					new Type<Collection<String>>() {
 					}.getType());
 			}
@@ -117,7 +117,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 	protected Request addEdgeDefinitionRequest(final EdgeDefinition definition) {
 		final Request request = new Request(db.name(), RequestType.POST,
 				executor.createPath(ArangoDBConstants.PATH_API_GHARIAL, name, ArangoDBConstants.EDGE));
-		request.setBody(executor.serialize(definition));
+		request.setBody(util().serialize(definition));
 		return request;
 	}
 
@@ -125,7 +125,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 		return new ResponseDeserializer<GraphEntity>() {
 			@Override
 			public GraphEntity deserialize(final Response response) throws VPackException {
-				return executor.deserialize(response.getBody().get(ArangoDBConstants.GRAPH), GraphEntity.class);
+				return util().deserialize(response.getBody().get(ArangoDBConstants.GRAPH), GraphEntity.class);
 			}
 		};
 	}
@@ -133,7 +133,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 	protected Request replaceEdgeDefinitionRequest(final EdgeDefinition definition) {
 		final Request request = new Request(db.name(), RequestType.PUT, executor.createPath(
 			ArangoDBConstants.PATH_API_GHARIAL, name, ArangoDBConstants.EDGE, definition.getCollection()));
-		request.setBody(executor.serialize(definition));
+		request.setBody(util().serialize(definition));
 		return request;
 	}
 
@@ -141,7 +141,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 		return new ResponseDeserializer<GraphEntity>() {
 			@Override
 			public GraphEntity deserialize(final Response response) throws VPackException {
-				return executor.deserialize(response.getBody().get(ArangoDBConstants.GRAPH), GraphEntity.class);
+				return util().deserialize(response.getBody().get(ArangoDBConstants.GRAPH), GraphEntity.class);
 			}
 		};
 	}
@@ -155,7 +155,7 @@ public class InternalArangoGraph<A extends InternalArangoDB<E, R, C>, D extends 
 		return new ResponseDeserializer<GraphEntity>() {
 			@Override
 			public GraphEntity deserialize(final Response response) throws VPackException {
-				return executor.deserialize(response.getBody().get(ArangoDBConstants.GRAPH), GraphEntity.class);
+				return util().deserialize(response.getBody().get(ArangoDBConstants.GRAPH), GraphEntity.class);
 			}
 		};
 	}

--- a/src/main/java/com/arangodb/internal/InternalArangoVertexCollection.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoVertexCollection.java
@@ -33,6 +33,7 @@ import com.arangodb.model.VertexCreateOptions;
 import com.arangodb.model.VertexDeleteOptions;
 import com.arangodb.model.VertexReplaceOptions;
 import com.arangodb.model.VertexUpdateOptions;
+import com.arangodb.util.ArangoSerializer;
 import com.arangodb.velocypack.VPackSlice;
 import com.arangodb.velocypack.exception.VPackException;
 import com.arangodb.velocystream.Request;
@@ -50,7 +51,7 @@ public class InternalArangoVertexCollection<A extends InternalArangoDB<E, R, C>,
 	private final String name;
 
 	public InternalArangoVertexCollection(final G graph, final String name) {
-		super(graph.executor());
+		super(graph.executor(), graph.util());
 		this.graph = graph;
 		this.name = name;
 	}
@@ -73,7 +74,7 @@ public class InternalArangoVertexCollection<A extends InternalArangoDB<E, R, C>,
 				executor.createPath(ArangoDBConstants.PATH_API_GHARIAL, graph.name(), ArangoDBConstants.VERTEX, name));
 		final VertexCreateOptions params = (options != null ? options : new VertexCreateOptions());
 		request.putQueryParam(ArangoDBConstants.WAIT_FOR_SYNC, params.getWaitForSync());
-		request.setBody(executor.serialize(value));
+		request.setBody(util().serialize(value));
 		return request;
 	}
 
@@ -82,7 +83,7 @@ public class InternalArangoVertexCollection<A extends InternalArangoDB<E, R, C>,
 			@Override
 			public VertexEntity deserialize(final Response response) throws VPackException {
 				final VPackSlice body = response.getBody().get(ArangoDBConstants.VERTEX);
-				final VertexEntity doc = executor.deserialize(body, VertexEntity.class);
+				final VertexEntity doc = util().deserialize(body, VertexEntity.class);
 				final Map<DocumentField.Type, String> values = new HashMap<DocumentField.Type, String>();
 				values.put(DocumentField.Type.ID, doc.getId());
 				values.put(DocumentField.Type.KEY, doc.getKey());
@@ -107,7 +108,7 @@ public class InternalArangoVertexCollection<A extends InternalArangoDB<E, R, C>,
 		return new ResponseDeserializer<T>() {
 			@Override
 			public T deserialize(final Response response) throws VPackException {
-				return executor.deserialize(response.getBody().get(ArangoDBConstants.VERTEX), type);
+				return util().deserialize(response.getBody().get(ArangoDBConstants.VERTEX), type);
 			}
 		};
 	}
@@ -119,7 +120,7 @@ public class InternalArangoVertexCollection<A extends InternalArangoDB<E, R, C>,
 		final VertexReplaceOptions params = (options != null ? options : new VertexReplaceOptions());
 		request.putQueryParam(ArangoDBConstants.WAIT_FOR_SYNC, params.getWaitForSync());
 		request.putHeaderParam(ArangoDBConstants.IF_MATCH, params.getIfMatch());
-		request.setBody(executor.serialize(value));
+		request.setBody(util().serialize(value));
 		return request;
 	}
 
@@ -128,7 +129,7 @@ public class InternalArangoVertexCollection<A extends InternalArangoDB<E, R, C>,
 			@Override
 			public VertexUpdateEntity deserialize(final Response response) throws VPackException {
 				final VPackSlice body = response.getBody().get(ArangoDBConstants.VERTEX);
-				final VertexUpdateEntity doc = executor.deserialize(body, VertexUpdateEntity.class);
+				final VertexUpdateEntity doc = util().deserialize(body, VertexUpdateEntity.class);
 				final Map<DocumentField.Type, String> values = new HashMap<DocumentField.Type, String>();
 				values.put(DocumentField.Type.REV, doc.getRev());
 				executor.documentCache().setValues(value, values);
@@ -146,7 +147,7 @@ public class InternalArangoVertexCollection<A extends InternalArangoDB<E, R, C>,
 		request.putQueryParam(ArangoDBConstants.KEEP_NULL, params.getKeepNull());
 		request.putQueryParam(ArangoDBConstants.WAIT_FOR_SYNC, params.getWaitForSync());
 		request.putHeaderParam(ArangoDBConstants.IF_MATCH, params.getIfMatch());
-		request.setBody(executor.serialize(value, true));
+		request.setBody(util().serialize(value, new ArangoSerializer.Options().serializeNullValues(true)));
 		return request;
 	}
 
@@ -155,7 +156,7 @@ public class InternalArangoVertexCollection<A extends InternalArangoDB<E, R, C>,
 			@Override
 			public VertexUpdateEntity deserialize(final Response response) throws VPackException {
 				final VPackSlice body = response.getBody().get(ArangoDBConstants.VERTEX);
-				return executor.deserialize(body, VertexUpdateEntity.class);
+				return util().deserialize(body, VertexUpdateEntity.class);
 			}
 		};
 	}

--- a/src/main/java/com/arangodb/internal/util/ArangoUtilImpl.java
+++ b/src/main/java/com/arangodb/internal/util/ArangoUtilImpl.java
@@ -26,14 +26,14 @@ import java.util.Map;
 import com.arangodb.ArangoDBException;
 import com.arangodb.util.ArangoDeserializer;
 import com.arangodb.util.ArangoSerializer;
-import com.arangodb.util.ArangoUtil;
+import com.arangodb.util.ArangoSerialization;
 import com.arangodb.velocypack.VPackSlice;
 
 /**
  * @author Mark - mark at arangodb.com
  *
  */
-public class ArangoUtilImpl implements ArangoUtil {
+public class ArangoUtilImpl implements ArangoSerialization {
 
 	private final ArangoSerializer serializer;
 	private final ArangoDeserializer deserializer;
@@ -50,28 +50,38 @@ public class ArangoUtilImpl implements ArangoUtil {
 	}
 
 	@Override
+	public VPackSlice serialize(final Object entity, final Options options) throws ArangoDBException {
+		return serializer.serialize(entity, options);
+	}
+
+	@Override
+	@Deprecated
 	public VPackSlice serialize(final Object entity, final boolean serializeNullValues) throws ArangoDBException {
 		return serializer.serialize(entity, serializeNullValues);
 	}
 
 	@Override
+	@Deprecated
 	public VPackSlice serialize(final Object entity, final boolean serializeNullValues, final boolean stringAsJson)
 			throws ArangoDBException {
 		return serializer.serialize(entity, serializeNullValues, stringAsJson);
 	}
 
 	@Override
+	@Deprecated
 	public VPackSlice serialize(final Object entity, final Type type) throws ArangoDBException {
 		return serializer.serialize(entity, type);
 	}
 
 	@Override
+	@Deprecated
 	public VPackSlice serialize(final Object entity, final Type type, final boolean serializeNullValues)
 			throws ArangoDBException {
 		return serializer.serialize(entity, type, serializeNullValues);
 	}
 
 	@Override
+	@Deprecated
 	public VPackSlice serialize(final Object entity, final Type type, final Map<String, Object> additionalFields)
 			throws ArangoDBException {
 		return serializer.serialize(entity, type, additionalFields);

--- a/src/main/java/com/arangodb/internal/velocypack/VPackDeserializers.java
+++ b/src/main/java/com/arangodb/internal/velocypack/VPackDeserializers.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.arangodb.entity.ArangoDBVersion;
+import com.arangodb.entity.ArangoDBVersion.License;
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.entity.BaseEdgeDocument;
 import com.arangodb.entity.CollectionStatus;
@@ -128,6 +130,16 @@ public class VPackDeserializers {
 			final VPackSlice vpack,
 			final VPackDeserializationContext context) throws VPackException {
 			return LogLevel.fromLevel(vpack.getAsInt());
+		}
+	};
+
+	public static final VPackDeserializer<ArangoDBVersion.License> LICENSE = new VPackDeserializer<ArangoDBVersion.License>() {
+		@Override
+		public License deserialize(
+			final VPackSlice parent,
+			final VPackSlice vpack,
+			final VPackDeserializationContext context) throws VPackException {
+			return License.valueOf(vpack.getAsString().toUpperCase());
 		}
 	};
 }

--- a/src/main/java/com/arangodb/internal/velocypack/VPackDriverModule.java
+++ b/src/main/java/com/arangodb/internal/velocypack/VPackDriverModule.java
@@ -23,6 +23,7 @@ package com.arangodb.internal.velocypack;
 import java.lang.reflect.Field;
 import java.util.Date;
 
+import com.arangodb.entity.ArangoDBVersion;
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.entity.BaseEdgeDocument;
 import com.arangodb.entity.CollectionStatus;
@@ -73,6 +74,7 @@ public class VPackDriverModule implements VPackModule, VPackParserModule {
 		context.registerDeserializer(BaseEdgeDocument.class, VPackDeserializers.BASE_EDGE_DOCUMENT);
 		context.registerDeserializer(QueryEntity.PROPERTY_STARTED, Date.class, VPackDeserializers.DATE_STRING);
 		context.registerDeserializer(LogLevel.class, VPackDeserializers.LOG_LEVEL);
+		context.registerDeserializer(ArangoDBVersion.License.class, VPackDeserializers.LICENSE);
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/internal/velocystream/Communication.java
+++ b/src/main/java/com/arangodb/internal/velocystream/Communication.java
@@ -34,7 +34,7 @@ import com.arangodb.ArangoDBException;
 import com.arangodb.entity.ErrorEntity;
 import com.arangodb.internal.ArangoDBConstants;
 import com.arangodb.internal.CollectionCache;
-import com.arangodb.util.ArangoUtil;
+import com.arangodb.util.ArangoSerialization;
 import com.arangodb.velocypack.VPackSlice;
 import com.arangodb.velocypack.exception.VPackParserException;
 import com.arangodb.velocystream.Request;
@@ -51,7 +51,7 @@ public abstract class Communication<R, C extends Connection> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(Communication.class);
 
 	protected static final AtomicLong mId = new AtomicLong(0L);
-	protected final ArangoUtil util;
+	protected final ArangoSerialization util;
 	protected final ConnectionPool<C> connectionPool;
 	protected final CollectionCache collectionCache;
 
@@ -61,7 +61,7 @@ public abstract class Communication<R, C extends Connection> {
 	protected final Integer chunksize;
 
 	protected Communication(final Integer timeout, final String user, final String password, final Boolean useSsl,
-		final SSLContext sslContext, final ArangoUtil util, final CollectionCache collectionCache,
+		final SSLContext sslContext, final ArangoSerialization util, final CollectionCache collectionCache,
 		final Integer chunksize, final ConnectionPool<C> connectionPool) {
 		this.user = user;
 		this.password = password;

--- a/src/main/java/com/arangodb/internal/velocystream/CommunicationSync.java
+++ b/src/main/java/com/arangodb/internal/velocystream/CommunicationSync.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import com.arangodb.ArangoDBException;
 import com.arangodb.internal.ArangoDBConstants;
 import com.arangodb.internal.CollectionCache;
-import com.arangodb.util.ArangoUtil;
+import com.arangodb.util.ArangoSerialization;
 import com.arangodb.velocypack.exception.VPackParserException;
 import com.arangodb.velocystream.Request;
 import com.arangodb.velocystream.Response;
@@ -93,7 +93,7 @@ public class CommunicationSync extends Communication<Response, ConnectionSync> {
 		}
 
 		public Communication<Response, ConnectionSync> build(
-			final ArangoUtil util,
+			final ArangoSerialization util,
 			final CollectionCache collectionCache) {
 			return new CommunicationSync(hostHandler, timeout, user, password, useSsl, sslContext, util,
 					collectionCache, chunksize, maxConnections);
@@ -101,7 +101,7 @@ public class CommunicationSync extends Communication<Response, ConnectionSync> {
 	}
 
 	protected CommunicationSync(final HostHandler hostHandler, final Integer timeout, final String user,
-		final String password, final Boolean useSsl, final SSLContext sslContext, final ArangoUtil util,
+		final String password, final Boolean useSsl, final SSLContext sslContext, final ArangoSerialization util,
 		final CollectionCache collectionCache, final Integer chunksize, final Integer maxConnections) {
 		super(timeout, user, password, useSsl, sslContext, util, collectionCache, chunksize,
 				new ConnectionPool<ConnectionSync>(maxConnections) {

--- a/src/main/java/com/arangodb/util/ArangoSerialization.java
+++ b/src/main/java/com/arangodb/util/ArangoSerialization.java
@@ -24,6 +24,6 @@ package com.arangodb.util;
  * @author Mark - mark at arangodb.com
  * 
  */
-public interface ArangoUtil extends ArangoSerializer, ArangoDeserializer {
+public interface ArangoSerialization extends ArangoSerializer, ArangoDeserializer {
 
 }

--- a/src/main/java/com/arangodb/util/ArangoSerializer.java
+++ b/src/main/java/com/arangodb/util/ArangoSerializer.java
@@ -21,6 +21,7 @@
 package com.arangodb.util;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Map;
 
 import com.arangodb.ArangoDBException;
@@ -31,6 +32,81 @@ import com.arangodb.velocypack.VPackSlice;
  *
  */
 public interface ArangoSerializer {
+
+	public static class Options {
+		private Type type;
+		private boolean serializeNullValues;
+		private Map<String, Object> additionalFields;
+		private boolean stringAsJson;
+
+		public Options() {
+			super();
+			serializeNullValues = false;
+			stringAsJson = false;
+			additionalFields = Collections.<String, Object> emptyMap();
+		}
+
+		/**
+		 * 
+		 * @param type
+		 *            The source type of the Object.
+		 * @return options
+		 */
+		public Options type(final Type type) {
+			this.type = type;
+			return this;
+		}
+
+		/**
+		 * 
+		 * @param serializeNullValues
+		 *            Whether or not null values should be excluded from serialization.
+		 * @return options
+		 */
+		public Options serializeNullValues(final boolean serializeNullValues) {
+			this.serializeNullValues = serializeNullValues;
+			return this;
+		}
+
+		/**
+		 * 
+		 * @param additionalFields
+		 *            Additional Key/Value pairs to include in the created VelocyPack.
+		 * @return options
+		 */
+		public Options additionalFields(final Map<String, Object> additionalFields) {
+			this.additionalFields = additionalFields;
+			return this;
+		}
+
+		/**
+		 * 
+		 * @param stringAsJson
+		 *            Wheter or not String should be interpreted as json
+		 * @return options
+		 */
+		public Options stringAsJson(final boolean stringAsJson) {
+			this.stringAsJson = stringAsJson;
+			return this;
+		}
+
+		public Type getType() {
+			return type;
+		}
+
+		public boolean isSerializeNullValues() {
+			return serializeNullValues;
+		}
+
+		public Map<String, Object> getAdditionalFields() {
+			return additionalFields;
+		}
+
+		public boolean isStringAsJson() {
+			return stringAsJson;
+		}
+
+	}
 
 	/**
 	 * Serialize a given Object to VelocyPack
@@ -47,17 +123,32 @@ public interface ArangoSerializer {
 	 * 
 	 * @param entity
 	 *            The Object to serialize. If it is from type String, it will be handled as a Json.
+	 * @param options
+	 *            Additional options
+	 * @return the serialized VelocyPack
+	 * @throws ArangoDBException
+	 */
+	VPackSlice serialize(final Object entity, final Options options) throws ArangoDBException;
+
+	/**
+	 * Serialize a given Object to VelocyPack
+	 * 
+	 * @deprecated use {@link #serialize(Object, Options)} instead
+	 * @param entity
+	 *            The Object to serialize. If it is from type String, it will be handled as a Json.
 	 * @param serializeNullValues
 	 *            Whether or not null values should be excluded from serialization.
 	 * @return the serialized VelocyPack
 	 * @throws ArangoDBException
 	 */
+	@Deprecated
 	VPackSlice serialize(final Object entity, final boolean serializeNullValues) throws ArangoDBException;
 
 	/**
 	 * Serialize a given Object to VelocyPack. If the Object is from type Iterable<String> the String will be
 	 * interpreted as Json
 	 * 
+	 * @deprecated use {@link #serialize(Object, Options)} instead
 	 * @param entity
 	 *            The Object to serialize. If it is from type String, it will be handled as a Json.
 	 * @param serializeNullValues
@@ -66,6 +157,7 @@ public interface ArangoSerializer {
 	 * @return the serialized VelocyPack
 	 * @throws ArangoDBException
 	 */
+	@Deprecated
 	VPackSlice serialize(final Object entity, final boolean serializeNullValues, final boolean stringAsJson)
 			throws ArangoDBException;
 
@@ -73,6 +165,7 @@ public interface ArangoSerializer {
 	 * Serialize a given Object to VelocyPack. This method is for serialization of types with generic parameter like
 	 * Collection, List, Map.
 	 * 
+	 * @deprecated use {@link #serialize(Object, Options)} instead
 	 * @param entity
 	 *            The Object to serialize
 	 * @param type
@@ -80,12 +173,14 @@ public interface ArangoSerializer {
 	 * @return the serialized VelocyPack
 	 * @throws ArangoDBException
 	 */
+	@Deprecated
 	VPackSlice serialize(final Object entity, final Type type) throws ArangoDBException;
 
 	/**
 	 * Serialize a given Object to VelocyPack. This method is for serialization of types with generic parameter like
 	 * Collection, List, Map.
 	 * 
+	 * @deprecated use {@link #serialize(Object, Options)} instead
 	 * @param entity
 	 *            The Object to serialize
 	 * @param type
@@ -95,6 +190,7 @@ public interface ArangoSerializer {
 	 * @return the serialized VelocyPack
 	 * @throws ArangoDBException
 	 */
+	@Deprecated
 	VPackSlice serialize(final Object entity, final Type type, final boolean serializeNullValues)
 			throws ArangoDBException;
 
@@ -102,6 +198,7 @@ public interface ArangoSerializer {
 	 * Serialize a given Object to VelocyPack. This method is for serialization of types with generic parameter like
 	 * Collection, List, Map.
 	 * 
+	 * @deprecated use {@link #serialize(Object, Options)} instead
 	 * @param entity
 	 *            The Object to serialize
 	 * @param type
@@ -113,6 +210,7 @@ public interface ArangoSerializer {
 	 * @return the serialized VelocyPack
 	 * @throws ArangoDBException
 	 */
+	@Deprecated
 	VPackSlice serialize(final Object entity, final Type type, final Map<String, Object> additionalFields)
 			throws ArangoDBException;
 

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -1731,6 +1731,9 @@ public class ArangoCollectionTest extends BaseTest {
 
 	@Test
 	public void rename() {
+		if (arangoDB.getRole() != ServerRole.SINGLE) {
+			return;
+		}
 		try {
 			final CollectionEntity result = db.collection(COLLECTION_NAME).rename(COLLECTION_NAME + "1");
 			assertThat(result, is(notNullValue()));

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -56,6 +56,7 @@ import com.arangodb.entity.DocumentUpdateEntity;
 import com.arangodb.entity.IndexEntity;
 import com.arangodb.entity.IndexType;
 import com.arangodb.entity.MultiDocumentEntity;
+import com.arangodb.entity.ServerRole;
 import com.arangodb.model.CollectionCreateOptions;
 import com.arangodb.model.CollectionPropertiesOptions;
 import com.arangodb.model.DocumentCreateOptions;
@@ -737,7 +738,9 @@ public class ArangoCollectionTest extends BaseTest {
 		assertThat(indexResult.getId(), startsWith(COLLECTION_NAME));
 		assertThat(indexResult.getIsNewlyCreated(), is(true));
 		assertThat(indexResult.getMinLength(), is(nullValue()));
-		assertThat(indexResult.getSelectivityEstimate(), is(1));
+		if (arangoDB.getRole() == ServerRole.SINGLE) {
+			assertThat(indexResult.getSelectivityEstimate(), is(1));
+		}
 		assertThat(indexResult.getSparse(), is(false));
 		assertThat(indexResult.getType(), is(IndexType.hash));
 		assertThat(indexResult.getUnique(), is(false));

--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1023,8 +1024,9 @@ public class ArangoDatabaseTest extends BaseTest {
 			assertThat(vertices.size(), is(4));
 
 			final Iterator<BaseDocument> verticesIterator = vertices.iterator();
-			for (final String e : new String[] { "Alice", "Bob", "Charlie", "Dave" }) {
-				assertThat(verticesIterator.next().getKey(), is(e));
+			final Collection<String> v = Arrays.asList(new String[] { "Alice", "Bob", "Charlie", "Dave" });
+			for (; verticesIterator.hasNext();) {
+				assertThat(v.contains(verticesIterator.next().getKey()), is(true));
 			}
 
 			final Collection<PathEntity<BaseDocument, BaseEdgeDocument>> paths = traversal.getPaths();

--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -112,6 +112,72 @@ public class ArangoDatabaseTest extends BaseTest {
 	}
 
 	@Test
+	public void createCollectionWithReplicationFactor() {
+		if (arangoDB.getRole() == ServerRole.SINGLE) {
+			return;
+		}
+		try {
+			final CollectionEntity result = db.createCollection(COLLECTION_NAME,
+				new CollectionCreateOptions().replicationFactor(2));
+			assertThat(result, is(notNullValue()));
+			assertThat(result.getId(), is(notNullValue()));
+			assertThat(db.collection(COLLECTION_NAME).getProperties().getReplicationFactor(), is(2));
+		} finally {
+			db.collection(COLLECTION_NAME).drop();
+		}
+	}
+
+	@Test
+	public void createCollectionWithNumberOfShards() {
+		if (arangoDB.getRole() == ServerRole.SINGLE) {
+			return;
+		}
+		try {
+			final CollectionEntity result = db.createCollection(COLLECTION_NAME,
+				new CollectionCreateOptions().numberOfShards(2));
+			assertThat(result, is(notNullValue()));
+			assertThat(result.getId(), is(notNullValue()));
+			assertThat(db.collection(COLLECTION_NAME).getProperties().getNumberOfShards(), is(2));
+		} finally {
+			db.collection(COLLECTION_NAME).drop();
+		}
+	}
+
+	@Test
+	public void createCollectionWithNumberOfShardsAndShardKey() {
+		if (arangoDB.getRole() == ServerRole.SINGLE) {
+			return;
+		}
+		try {
+			final CollectionEntity result = db.createCollection(COLLECTION_NAME,
+				new CollectionCreateOptions().numberOfShards(2).shardKeys("a"));
+			assertThat(result, is(notNullValue()));
+			assertThat(result.getId(), is(notNullValue()));
+			assertThat(db.collection(COLLECTION_NAME).getProperties().getNumberOfShards(), is(2));
+			assertThat(db.collection(COLLECTION_NAME).getProperties().getShardKeys().size(), is(1));
+		} finally {
+			db.collection(COLLECTION_NAME).drop();
+		}
+	}
+
+	@Test
+	public void createCollectionWithNumberOfShardsAndShardKeys() {
+		if (arangoDB.getRole() == ServerRole.SINGLE) {
+			return;
+		}
+		try {
+			final CollectionEntity result = db.createCollection(COLLECTION_NAME,
+				new CollectionCreateOptions().numberOfShards(2).shardKeys("a", "b"));
+			assertThat(result, is(notNullValue()));
+			assertThat(result.getId(), is(notNullValue()));
+			assertThat(db.collection(COLLECTION_NAME).getProperties().getNumberOfShards(), is(2));
+			assertThat(db.collection(COLLECTION_NAME).getProperties().getShardKeys().size(), is(2));
+		} finally {
+			db.collection(COLLECTION_NAME).drop();
+		}
+	}
+
+	@Test
 	public void deleteCollection() {
 		db.createCollection(COLLECTION_NAME, null);
 		db.collection(COLLECTION_NAME).drop();

--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -1057,6 +1058,20 @@ public class ArangoDatabaseTest extends BaseTest {
 			assertThat(document.getKey(), is("123"));
 		} finally {
 			db.collection(COLLECTION_NAME).drop();
+		}
+	}
+
+	@Test
+	public void shouldIncludeExceptionMessage() {
+		final String exceptionMessage = "My error context";
+		final String action = "function (params) {"
+				+ "throw '" + exceptionMessage + "';"
+				+ "}";
+		try {
+			db.transaction(action, VPackSlice.class, null);
+			fail();
+		} catch (final ArangoDBException e) {
+			assertTrue(e.getException().contains(exceptionMessage));
 		}
 	}
 

--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -51,6 +51,7 @@ import com.arangodb.entity.ArangoDBVersion;
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.entity.BaseEdgeDocument;
 import com.arangodb.entity.CollectionEntity;
+import com.arangodb.entity.CollectionPropertiesEntity;
 import com.arangodb.entity.CollectionType;
 import com.arangodb.entity.DatabaseEntity;
 import com.arangodb.entity.GraphEntity;
@@ -153,8 +154,9 @@ public class ArangoDatabaseTest extends BaseTest {
 				new CollectionCreateOptions().numberOfShards(2).shardKeys("a"));
 			assertThat(result, is(notNullValue()));
 			assertThat(result.getId(), is(notNullValue()));
-			assertThat(db.collection(COLLECTION_NAME).getProperties().getNumberOfShards(), is(2));
-			assertThat(db.collection(COLLECTION_NAME).getProperties().getShardKeys().size(), is(1));
+			final CollectionPropertiesEntity properties = db.collection(COLLECTION_NAME).getProperties();
+			assertThat(properties.getNumberOfShards(), is(2));
+			assertThat(properties.getShardKeys().size(), is(1));
 		} finally {
 			db.collection(COLLECTION_NAME).drop();
 		}
@@ -170,8 +172,9 @@ public class ArangoDatabaseTest extends BaseTest {
 				new CollectionCreateOptions().numberOfShards(2).shardKeys("a", "b"));
 			assertThat(result, is(notNullValue()));
 			assertThat(result.getId(), is(notNullValue()));
-			assertThat(db.collection(COLLECTION_NAME).getProperties().getNumberOfShards(), is(2));
-			assertThat(db.collection(COLLECTION_NAME).getProperties().getShardKeys().size(), is(2));
+			final CollectionPropertiesEntity properties = db.collection(COLLECTION_NAME).getProperties();
+			assertThat(properties.getNumberOfShards(), is(2));
+			assertThat(properties.getShardKeys().size(), is(2));
 		} finally {
 			db.collection(COLLECTION_NAME).drop();
 		}

--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -43,7 +43,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import com.arangodb.entity.AqlExecutionExplainEntity;
-import com.arangodb.entity.AqlExecutionExplainEntity.ExecutionNode;
 import com.arangodb.entity.AqlExecutionExplainEntity.ExecutionPlan;
 import com.arangodb.entity.AqlFunctionEntity;
 import com.arangodb.entity.AqlParseEntity;
@@ -453,6 +452,9 @@ public class ArangoDatabaseTest extends BaseTest {
 
 	@Test
 	public void queryWithCache() throws InterruptedException {
+		if (arangoDB.getRole() != ServerRole.SINGLE) {
+			return;
+		}
 		try {
 			db.createCollection(COLLECTION_NAME, null);
 			for (int i = 0; i < 10; i++) {
@@ -613,20 +615,7 @@ public class ArangoDatabaseTest extends BaseTest {
 		assertThat(plan.getEstimatedNrItems(), greaterThan(0));
 		assertThat(plan.getVariables().size(), is(1));
 		assertThat(plan.getVariables().iterator().next().getName(), is("i"));
-		assertThat(plan.getNodes().size(), is(3));
-		final Iterator<ExecutionNode> iterator = plan.getNodes().iterator();
-		final ExecutionNode singletonNode = iterator.next();
-		assertThat(singletonNode.getType(), is("SingletonNode"));
-		final ExecutionNode collectionNode = iterator.next();
-		assertThat(collectionNode.getType(), is("EnumerateCollectionNode"));
-		assertThat(collectionNode.getDatabase(), is("_system"));
-		assertThat(collectionNode.getCollection(), is("_apps"));
-		assertThat(collectionNode.getOutVariable(), is(notNullValue()));
-		assertThat(collectionNode.getOutVariable().getName(), is("i"));
-		final ExecutionNode returnNode = iterator.next();
-		assertThat(returnNode.getType(), is("ReturnNode"));
-		assertThat(returnNode.getInVariable(), is(notNullValue()));
-		assertThat(returnNode.getInVariable().getName(), is("i"));
+		assertThat(plan.getNodes().size(), is(greaterThan(0)));
 	}
 
 	@Test

--- a/src/test/java/com/arangodb/ArangoGraphTest.java
+++ b/src/test/java/com/arangodb/ArangoGraphTest.java
@@ -35,10 +35,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.arangodb.entity.ArangoDBVersion.License;
 import com.arangodb.entity.CollectionType;
 import com.arangodb.entity.EdgeDefinition;
 import com.arangodb.entity.GraphEntity;
 import com.arangodb.model.CollectionCreateOptions;
+import com.arangodb.model.GraphCreateOptions;
 
 /**
  * @author Mark - mark at arangodb.com
@@ -189,5 +191,22 @@ public class ArangoGraphTest extends BaseTest {
 		final Collection<EdgeDefinition> edgeDefinitions = graph.getEdgeDefinitions();
 		assertThat(edgeDefinitions.size(), is(1));
 		assertThat(edgeDefinitions.iterator().next().getCollection(), is(EDGE_COL_2));
+	}
+
+	@Test
+	public void smartGraph() {
+		if (arangoDB.getVersion().getLicense() == License.ENTERPRISE) {
+			teardown();
+			final Collection<EdgeDefinition> edgeDefinitions = new ArrayList<EdgeDefinition>();
+			edgeDefinitions.add(new EdgeDefinition().collection(EDGE_COL_1).from(VERTEX_COL_1).to(VERTEX_COL_2));
+			edgeDefinitions
+					.add(new EdgeDefinition().collection(EDGE_COL_2).from(VERTEX_COL_2).to(VERTEX_COL_1, VERTEX_COL_3));
+			final GraphEntity graph = db.createGraph(GRAPH_NAME, edgeDefinitions,
+				new GraphCreateOptions().isSmart(true).smartGraphAttribute("test").numberOfShards(2));
+			assertThat(graph, is(notNullValue()));
+			assertThat(graph.getIsSmart(), is(true));
+			assertThat(graph.getSmartGraphAttribute(), is("test"));
+			assertThat(graph.getNumberOfShards(), is(2));
+		}
 	}
 }

--- a/src/test/java/com/arangodb/ArangoSslTest.java
+++ b/src/test/java/com/arangodb/ArangoSslTest.java
@@ -70,7 +70,9 @@ public class ArangoSslTest {
 		final SSLContext sc = SSLContext.getInstance("TLS");
 		sc.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
 
-		final ArangoDB arangoDB = new ArangoDB.Builder().port(8530).useSsl(true).sslContext(sc).build();
+		final ArangoDB arangoDB = new ArangoDB.Builder()
+				.loadProperties(ArangoSslTest.class.getResourceAsStream("/arangodb-ssl.properties")).useSsl(true)
+				.sslContext(sc).build();
 		final ArangoDBVersion version = arangoDB.getVersion();
 		assertThat(version, is(notNullValue()));
 	}
@@ -79,7 +81,9 @@ public class ArangoSslTest {
 	@Ignore
 	public void connectWithoutValidSslContext() throws Exception {
 		try {
-			final ArangoDB arangoDB = new ArangoDB.Builder().port(8530).useSsl(true).build();
+			final ArangoDB arangoDB = new ArangoDB.Builder()
+					.loadProperties(ArangoSslTest.class.getResourceAsStream("/arangodb-ssl.properties")).useSsl(true)
+					.build();
 			arangoDB.getVersion();
 			fail("this should fail");
 		} catch (final ArangoDBException ex) {

--- a/src/test/java/com/arangodb/example/graph/AQLActorsAndMoviesExample.java
+++ b/src/test/java/com/arangodb/example/graph/AQLActorsAndMoviesExample.java
@@ -77,8 +77,8 @@ public class AQLActorsAndMoviesExample {
 	@Test
 	public void allActorsActsInMovie1or2() {
 		final ArangoCursor<String> cursor = db.query(
-			"FOR x IN ANY 'movies/TheMatrix' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN x._id", null,
-			null, String.class);
+			"WITH actors FOR x IN ANY 'movies/TheMatrix' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN x._id",
+			null, null, String.class);
 		assertThat(cursor.asListRemaining(),
 			hasItems("actors/Keanu", "actors/Hugo", "actors/Emil", "actors/Carrie", "actors/Laurence"));
 	}
@@ -91,7 +91,7 @@ public class AQLActorsAndMoviesExample {
 	@Test
 	public void allActorsActsInMovie1or2UnionDistinct() {
 		final ArangoCursor<String> cursor = db.query(
-			"FOR x IN UNION_DISTINCT ((FOR y IN ANY 'movies/TheMatrix' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id), (FOR y IN ANY 'movies/TheDevilsAdvocate' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id)) RETURN x",
+			"WITH actors FOR x IN UNION_DISTINCT ((FOR y IN ANY 'movies/TheMatrix' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id), (FOR y IN ANY 'movies/TheDevilsAdvocate' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id)) RETURN x",
 			null, null, String.class);
 		assertThat(cursor.asListRemaining(), hasItems("actors/Emil", "actors/Hugo", "actors/Carrie", "actors/Laurence",
 			"actors/Keanu", "actors/Al", "actors/Charlize"));
@@ -105,7 +105,7 @@ public class AQLActorsAndMoviesExample {
 	@Test
 	public void allActorsActsInMovie1and2() {
 		final ArangoCursor<String> cursor = db.query(
-			"FOR x IN INTERSECTION ((FOR y IN ANY 'movies/TheMatrix' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id), (FOR y IN ANY 'movies/TheDevilsAdvocate' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id)) RETURN x",
+			"WITH actors FOR x IN INTERSECTION ((FOR y IN ANY 'movies/TheMatrix' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id), (FOR y IN ANY 'movies/TheDevilsAdvocate' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id)) RETURN x",
 			null, null, String.class);
 		assertThat(cursor.asListRemaining(), hasItems("actors/Keanu"));
 	}
@@ -118,7 +118,7 @@ public class AQLActorsAndMoviesExample {
 	@Test
 	public void allMoviesBetweenActor1andActor2() {
 		final ArangoCursor<String> cursor = db.query(
-			"FOR x IN INTERSECTION ((FOR y IN ANY 'actors/Hugo' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id), (FOR y IN ANY 'actors/Keanu' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id)) RETURN x",
+			"WITH movies FOR x IN INTERSECTION ((FOR y IN ANY 'actors/Hugo' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id), (FOR y IN ANY 'actors/Keanu' actsIn OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN y._id)) RETURN x",
 			null, null, String.class);
 		assertThat(cursor.asListRemaining(),
 			hasItems("movies/TheMatrixRevolutions", "movies/TheMatrixReloaded", "movies/TheMatrix"));

--- a/src/test/java/com/arangodb/example/graph/GraphTraversalsInAQLExample.java
+++ b/src/test/java/com/arangodb/example/graph/GraphTraversalsInAQLExample.java
@@ -48,7 +48,7 @@ public class GraphTraversalsInAQLExample extends BaseGraphTest {
 		Collection<String> result = cursor.asListRemaining();
 		assertThat(result.size(), is(10));
 
-		queryString = "FOR v IN 1..3 OUTBOUND 'circles/A' edges RETURN v._key";
+		queryString = "WITH circles FOR v IN 1..3 OUTBOUND 'circles/A' edges RETURN v._key";
 		cursor = db.query(queryString, null, null, String.class);
 		result = cursor.asListRemaining();
 		assertThat(result.size(), is(10));

--- a/src/test/java/com/arangodb/example/graph/ShortestPathInAQLExample.java
+++ b/src/test/java/com/arangodb/example/graph/ShortestPathInAQLExample.java
@@ -74,7 +74,7 @@ public class ShortestPathInAQLExample extends BaseGraphTest {
 		assertThat(collection.size(), is(4));
 		assertThat(collection, hasItems("A", "B", "C", "D"));
 
-		queryString = "FOR v, e IN OUTBOUND SHORTEST_PATH 'circles/A' TO 'circles/D' edges RETURN {'vertex': v._key, 'edge': e._key}";
+		queryString = "WITH circles FOR v, e IN OUTBOUND SHORTEST_PATH 'circles/A' TO 'circles/D' edges RETURN {'vertex': v._key, 'edge': e._key}";
 		cursor = db.query(queryString, null, null, Pair.class);
 		assertThat(collection.size(), is(4));
 		assertThat(collection, hasItems("A", "B", "C", "D"));

--- a/src/test/java/com/arangodb/example/ssl/SslExample.java
+++ b/src/test/java/com/arangodb/example/ssl/SslExample.java
@@ -69,7 +69,9 @@ public class SslExample {
 		final SSLContext sc = SSLContext.getInstance("TLS");
 		sc.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
 
-		final ArangoDB arangoDB = new ArangoDB.Builder().port(8530).useSsl(true).sslContext(sc).build();
+		final ArangoDB arangoDB = new ArangoDB.Builder()
+				.loadProperties(SslExample.class.getResourceAsStream("/arangodb-ssl.properties")).useSsl(true)
+				.sslContext(sc).build();
 		final ArangoDBVersion version = arangoDB.getVersion();
 		assertThat(version, is(notNullValue()));
 	}

--- a/src/test/java/com/arangodb/util/ArangoSerializationTest.java
+++ b/src/test/java/com/arangodb/util/ArangoSerializationTest.java
@@ -44,9 +44,9 @@ import com.arangodb.velocystream.Response;
  * @author Mark - mark at arangodb.com
  *
  */
-public class ArangoUtilTest {
+public class ArangoSerializationTest {
 
-	private static ArangoUtil util;
+	private static ArangoSerialization util;
 
 	@BeforeClass
 	public static void setup() {
@@ -74,7 +74,7 @@ public class ArangoUtilTest {
 	public void serializeNullValues() {
 		final BaseDocument entity = new BaseDocument();
 		entity.addAttribute("foo", null);
-		final VPackSlice vpack = util.serialize(entity, true);
+		final VPackSlice vpack = util.serialize(entity, new ArangoSerializer.Options().serializeNullValues(true));
 		assertThat(vpack.get("foo").isNull(), is(true));
 	}
 
@@ -84,8 +84,9 @@ public class ArangoUtilTest {
 		list.add(new BaseDocument());
 		list.add(new BaseDocument());
 
-		final VPackSlice vpack = util.serialize(list, new Type<Collection<BaseDocument>>() {
-		}.getType());
+		final VPackSlice vpack = util.serialize(list,
+			new ArangoSerializer.Options().type(new Type<Collection<BaseDocument>>() {
+			}.getType()));
 		assertThat(vpack.isArray(), is(true));
 		assertThat(vpack.getLength(), is(list.size()));
 	}

--- a/src/test/resources/arangodb-ssl.properties
+++ b/src/test/resources/arangodb-ssl.properties
@@ -1,0 +1,2 @@
+arangodb.hosts=127.0.0.1:8530
+arangodb.useSsl=true


### PR DESCRIPTION
I have added field "exception" to properly deserialize message from server, that in case of transaction, looks as follows:

{
  "exception": "My exception message",
  "error": true,
  "code": 500,
  "errorNum": 500,
  "errorMessage": "internal server error"
}

Having that said, I'm aware that field name "exception" that is String is not fortunate, however, at least it is consistent with message returned by db.