### PR TITLE
Throw error when failing to getDocument or to determine if documentExists

### DIFF
--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -215,7 +215,10 @@ public class ArangoCollection
 			if (LOGGER.isDebugEnabled()) {
 				LOGGER.debug(e.getMessage(), e);
 			}
-			return null;
+			if (e.getResponseCode() != null && e.getResponseCode().intValue() == 404) {
+				return null;
+			}
+			throw e;
 		}
 	}
 
@@ -527,7 +530,10 @@ public class ArangoCollection
 			executor.execute(documentExistsRequest(key, options), VPackSlice.class);
 			return true;
 		} catch (final ArangoDBException e) {
-			return false;
+			if (e.getResponseCode() != null && e.getResponseCode().intValue() == 404) {
+				return false;
+			}
+			throw e;
 		}
 	}
 

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -923,12 +923,11 @@ public class ArangoCollectionTest extends BaseTest {
 		assertThat(exists, is(true));
 	}
 
-	@Test
+	@Test(expected = ArangoDBException.class)
 	public void documentExistsIfMatchFail() {
 		db.collection(COLLECTION_NAME).insertDocument("{\"_key\":\"abc\"}", null);
 		final DocumentExistsOptions options = new DocumentExistsOptions().ifMatch("no");
-		final Boolean exists = db.collection(COLLECTION_NAME).documentExists("abc", options);
-		assertThat(exists, is(false));
+		db.collection(COLLECTION_NAME).documentExists("abc", options);
 	}
 
 	@Test
@@ -939,13 +938,12 @@ public class ArangoCollectionTest extends BaseTest {
 		assertThat(exists, is(true));
 	}
 
-	@Test
+	@Test(expected = ArangoDBException.class)
 	public void documentExistsIfNoneMatchFail() {
 		final DocumentCreateEntity<String> createResult = db.collection(COLLECTION_NAME)
 				.insertDocument("{\"_key\":\"abc\"}", null);
 		final DocumentExistsOptions options = new DocumentExistsOptions().ifNoneMatch(createResult.getRev());
-		final Boolean exists = db.collection(COLLECTION_NAME).documentExists("abc", options);
-		assertThat(exists, is(false));
+		db.collection(COLLECTION_NAME).documentExists("abc", options);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes issue #133 

Instead of silently consuming all the connection issues, throw an error so the user can decide how to handle the issue, and so that the user is not led to falsely believe that the document did not exist when it in fact could have existed, but the connection failed.

Some tests fail now, because it seems that the response code is sometimes not set on the ArangoDBException.