### PR TITLE
Docs: Use absolute link to SslExample.java in Setup.md

### DIFF
--- a/docs/Drivers/Java/Reference/Setup.md
+++ b/docs/Drivers/Java/Reference/Setup.md
@@ -64,7 +64,8 @@ In addition to set the configuration for HTTP you have to add the apache httpcli
 
 ## SSL
 
-To use SSL, you have to set the configuration `useSsl` to `true` and set a `SSLContext`. (see [example code](../../../../src/test/java/com/arangodb/example/ssl/SslExample.java))
+To use SSL, you have to set the configuration `useSsl` to `true` and set a `SSLContext`
+(see [example code](https://github.com/arangodb/arangodb-java-driver/blob/master/src/test/java/com/arangodb/example/ssl/SslExample.java)).
 
 ```Java
   ArangoDB arangoDB = new ArangoDB.Builder().useSsl(true).sslContext(sc).build();


### PR DESCRIPTION
We can't reference files from this repo when syncing and compiling the Drivers book for the hosted docs.

Relative links to non-existing files will be errors in an updated docs build script: https://github.com/arangodb/arangodb/pull/5704