### PR TITLE
Revert "Disable silent tests for ArangoDB 3.2"

### DIFF
--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -179,9 +179,6 @@ public class ArangoCollectionTest extends BaseTest {
 
 	@Test
 	public void insertDocumentSilent() {
-		if (!requireVersion(3, 3)) {
-			return;
-		}
 		final DocumentCreateEntity<BaseDocument> meta = db.collection(COLLECTION_NAME)
 				.insertDocument(new BaseDocument(), new DocumentCreateOptions().silent(true));
 		assertThat(meta, is(notNullValue()));
@@ -192,9 +189,6 @@ public class ArangoCollectionTest extends BaseTest {
 
 	@Test
 	public void insertDocumentSilentDontTouchInstance() {
-		if (!requireVersion(3, 3)) {
-			return;
-		}
 		final BaseDocument doc = new BaseDocument();
 		final String key = "testkey";
 		doc.setKey(key);
@@ -636,9 +630,6 @@ public class ArangoCollectionTest extends BaseTest {
 
 	@Test
 	public void updateDocumentSilent() {
-		if (!requireVersion(3, 3)) {
-			return;
-		}
 		final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME)
 				.insertDocument(new BaseDocument());
 		final DocumentUpdateEntity<BaseDocument> meta = db.collection(COLLECTION_NAME)
@@ -790,9 +781,6 @@ public class ArangoCollectionTest extends BaseTest {
 
 	@Test
 	public void replaceDocumentSilent() {
-		if (!requireVersion(3, 3)) {
-			return;
-		}
 		final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME)
 				.insertDocument(new BaseDocument());
 		final DocumentUpdateEntity<BaseDocument> meta = db.collection(COLLECTION_NAME)
@@ -871,9 +859,6 @@ public class ArangoCollectionTest extends BaseTest {
 
 	@Test
 	public void deleteDocumentSilent() {
-		if (!requireVersion(3, 3)) {
-			return;
-		}
 		final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME)
 				.insertDocument(new BaseDocument());
 		final DocumentDeleteEntity<BaseDocument> meta = db.collection(COLLECTION_NAME)

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -793,9 +793,6 @@ public class ArangoCollectionTest extends BaseTest {
 
 	@Test
 	public void replaceDocumentSilentDontTouchInstance() {
-		if (!requireVersion(3, 3)) {
-			return;
-		}
 		final BaseDocument doc = new BaseDocument();
 		final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME).insertDocument(doc);
 		final String revision = doc.getRevision();


### PR DESCRIPTION
This reverts commit 82783b23eb51d3ceb84c6036f0586af2fb64a658.

Blocked by https://github.com/arangodb/arangodb/issues/5750