### PR TITLE
Ensure Host connections closed immediately upon ExtendedHostResolver refresh

### DIFF
--- a/src/main/java/com/arangodb/internal/http/HttpConnection.java
+++ b/src/main/java/com/arangodb/internal/http/HttpConnection.java
@@ -229,8 +229,8 @@ public class HttpConnection implements Connection {
 
 	@Override
 	public void close() throws IOException {
-		cm.shutdown();
-		client.close();
+		IOUtils.closeQuietly(cm);
+		IOUtils.closeQuietly(client);
 	}
 
 	public Response execute(final Request request) throws ArangoDBException, IOException, SocketException {

--- a/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
+++ b/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.arangodb.internal.util.IOUtils;
+
 /**
  * @author Mark Vollmary
  *
@@ -68,7 +70,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
 	@Override
 	public void close() throws IOException {
 		for (final Connection connection : connections) {
-			connection.close();
+			IOUtils.closeQuietly(connection);
 		}
 		connections.clear();
 	}

--- a/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
+++ b/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
@@ -49,10 +49,10 @@ public class ConnectionPoolImpl implements ConnectionPool {
 		connections = new ArrayList<Connection>();
 		current = 0;
 
-		if (LOGGER.isInfoEnabled()) {
+		if (LOGGER.isWarnEnabled()) {
 			// instantiate an exception so we know the stacktrace to know the instances when this is invoked
 			Exception ex = new RuntimeException();
-			LOGGER.info("Instantiated a connection pool\n", ex);
+			LOGGER.warn("Instantiated a connection pool {}\n", this, ex);
 		}
 	}
 
@@ -81,6 +81,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
 			IOUtils.closeQuietly(connection);
 		}
 		connections.clear();
+		LOGGER.warn("connection pool {} is closing", this);
 	}
 
 }

--- a/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
+++ b/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
@@ -32,6 +32,8 @@ import com.arangodb.internal.util.IOUtils;
  */
 public class ConnectionPoolImpl implements ConnectionPool {
 
+	private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ConnectionPoolImpl.class);
+
 	private final HostDescription host;
 	private final int maxConnections;
 	private final List<Connection> connections;
@@ -46,6 +48,12 @@ public class ConnectionPoolImpl implements ConnectionPool {
 		this.factory = factory;
 		connections = new ArrayList<Connection>();
 		current = 0;
+
+		if (LOGGER.isInfoEnabled()) {
+			// instantiate an exception so we know the stacktrace to know the instances when this is invoked
+			Exception ex = new RuntimeException();
+			LOGGER.info("Instantiated a connection pool\n", ex);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
+++ b/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
@@ -32,8 +32,6 @@ import com.arangodb.internal.util.IOUtils;
  */
 public class ConnectionPoolImpl implements ConnectionPool {
 
-	private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ConnectionPoolImpl.class);
-
 	private final HostDescription host;
 	private final int maxConnections;
 	private final List<Connection> connections;
@@ -48,12 +46,6 @@ public class ConnectionPoolImpl implements ConnectionPool {
 		this.factory = factory;
 		connections = new ArrayList<Connection>();
 		current = 0;
-
-		if (LOGGER.isWarnEnabled()) {
-			// instantiate an exception so we know the stacktrace to know the instances when this is invoked
-			Exception ex = new RuntimeException();
-			LOGGER.warn("Instantiated a connection pool {}\n", this, ex);
-		}
 	}
 
 	@Override
@@ -81,7 +73,6 @@ public class ConnectionPoolImpl implements ConnectionPool {
 			IOUtils.closeQuietly(connection);
 		}
 		connections.clear();
-		LOGGER.warn("connection pool {} is closing", this);
 	}
 
 }

--- a/src/main/java/com/arangodb/internal/net/ExtendedHostResolver.java
+++ b/src/main/java/com/arangodb/internal/net/ExtendedHostResolver.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.arangodb.internal.util.HostUtils;
+import com.arangodb.internal.util.IOUtils;
 
 /**
  * @author Mark Vollmary
@@ -58,6 +59,9 @@ public class ExtendedHostResolver implements HostResolver {
 			lastUpdate = System.currentTimeMillis();
 			final Collection<String> endpoints = resolver.resolve(closeConnections);
 			if (!endpoints.isEmpty()) {
+				for(Host h : hosts) {
+					IOUtils.closeQuietly(h);
+				}
 				hosts.clear();
 			}
 			for (final String endpoint : endpoints) {

--- a/src/main/java/com/arangodb/internal/net/HostImpl.java
+++ b/src/main/java/com/arangodb/internal/net/HostImpl.java
@@ -31,6 +31,8 @@ import com.arangodb.internal.util.IOUtils;
  */
 public class HostImpl implements Host {
 
+	private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(HostImpl.class);
+
 	private final ConnectionPool connectionPool;
 	private final HostDescription description;
 
@@ -42,13 +44,15 @@ public class HostImpl implements Host {
 
 	@Override
 	public void close() throws IOException {
-		connectionPool.close();
+		IOUtils.closeQuietly(connectionPool);
+		LOGGER.warn("HostImpl {} being closed", this);
 	}
 
 	@Override
 	protected void finalize() throws Throwable {
 		super.finalize();
-		IOUtils.closeQuietly(connectionPool);
+		close();
+		LOGGER.warn("HostImpl {} finalize() called", this);
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/internal/net/HostImpl.java
+++ b/src/main/java/com/arangodb/internal/net/HostImpl.java
@@ -31,8 +31,6 @@ import com.arangodb.internal.util.IOUtils;
  */
 public class HostImpl implements Host {
 
-	private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(HostImpl.class);
-
 	private final ConnectionPool connectionPool;
 	private final HostDescription description;
 
@@ -45,14 +43,12 @@ public class HostImpl implements Host {
 	@Override
 	public void close() throws IOException {
 		IOUtils.closeQuietly(connectionPool);
-		LOGGER.warn("HostImpl {} being closed", this);
 	}
 
 	@Override
 	protected void finalize() throws Throwable {
 		super.finalize();
 		close();
-		LOGGER.warn("HostImpl {} finalize() called", this);
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/internal/net/HostImpl.java
+++ b/src/main/java/com/arangodb/internal/net/HostImpl.java
@@ -23,6 +23,7 @@ package com.arangodb.internal.net;
 import java.io.IOException;
 
 import com.arangodb.ArangoDBException;
+import com.arangodb.internal.util.IOUtils;
 
 /**
  * @author Mark Vollmary
@@ -42,6 +43,12 @@ public class HostImpl implements Host {
 	@Override
 	public void close() throws IOException {
 		connectionPool.close();
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		super.finalize();
+		IOUtils.closeQuietly(connectionPool);
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
@@ -48,7 +48,11 @@ public class RoundRobinHostHandler implements HostHandler {
 		if (fails > size) {
 			return null;
 		}
-		final int index = (current++) % size;
+		if (current < 0) {
+			current = 0;
+		}
+		final int index = current % size;
+		current++;
 		Host host = hosts.get(index);
 		if (hostHandle != null) {
 			final HostDescription hostDescription = hostHandle.getHost();

--- a/src/main/java/com/arangodb/internal/util/IOUtils.java
+++ b/src/main/java/com/arangodb/internal/util/IOUtils.java
@@ -28,6 +28,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 
+import com.arangodb.internal.net.Host;
+
 /**
  * @author Mark Vollmary
  *
@@ -78,6 +80,14 @@ public final class IOUtils {
 	public static void closeQuietly(final Closeable c) {
 		try {
 			c.close();
+		} catch (Exception e) {
+			// TODO: at least log a message. can we use SLF4J?
+		}
+	}
+
+	public static void closeQuietly(final Host h) {
+		try {
+			h.close();
 		} catch (Exception e) {
 			// TODO: at least log a message. can we use SLF4J?
 		}

--- a/src/main/java/com/arangodb/internal/util/IOUtils.java
+++ b/src/main/java/com/arangodb/internal/util/IOUtils.java
@@ -22,6 +22,7 @@ package com.arangodb.internal.util;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -72,5 +73,13 @@ public final class IOUtils {
 		}
 		buffer.flush();
 		return buffer.toByteArray();
+	}
+
+	public static void closeQuietly(final Closeable c) {
+		try {
+			c.close();
+		} catch (Exception e) {
+			// TODO: at least log a message. can we use SLF4J?
+		}
 	}
 }

--- a/src/main/java/com/arangodb/internal/velocystream/internal/VstConnection.java
+++ b/src/main/java/com/arangodb/internal/velocystream/internal/VstConnection.java
@@ -124,20 +124,17 @@ public abstract class VstConnection implements Connection {
 		executor.submit(new Callable<Void>() {
 			@Override
 			public Void call() throws Exception {
-				LOGGER.warn("started reader thread for {}", VstConnection.this);
 				final long openTime = new Date().getTime();
 				final Long ttlTime = ttl != null ? openTime + ttl : null;
 				final ChunkStore chunkStore = new ChunkStore(messageStore);
 				while (true) {
 					if (ttlTime != null && new Date().getTime() > ttlTime && messageStore.isEmpty()) {
 						close();
-						LOGGER.warn("reader thread for {} exiting due to ttl reached", VstConnection.this);
 						break;
 					}
 					if (!isOpen()) {
 						messageStore.clear(new IOException("The socket is closed."));
 						close();
-						LOGGER.warn("reader thread for {} exiting due to socket closed", VstConnection.this);
 						break;
 					}
 					try {
@@ -152,7 +149,6 @@ public abstract class VstConnection implements Connection {
 					} catch (final Exception e) {
 						messageStore.clear(e);
 						close();
-						LOGGER.warn("reader thread for {} exiting due to read error: {}", VstConnection.this, e.getMessage());
 						break;
 					}
 				}


### PR DESCRIPTION
When ExtendedHostResolver.resolve() is called and .isExpired() evaluates to true, we need to explicitly close each Host instance in the hosts list before clearing out the list. This is to ensure the connection pools managed in each Host (i.e. HostImpl) instance get cleaned up and prevent a memory leak.

This also most likely fixes #233 .