### PR TITLE
Added missing fail invocation in case of exception. Removed copy paste.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 		<logback-classic.version>1.1.3</logback-classic.version>
 		<hamcrest-all.version>1.3</hamcrest-all.version>
 		<junit.version>4.12</junit.version>
+		<easymock.version>4.0.2</easymock.version>
 	</properties>
 
 	<developers>
@@ -229,6 +230,12 @@
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.easymock</groupId>
+			<artifactId>easymock</artifactId>
+			<version>${easymock.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/arangodb/internal/Communication.java
+++ b/src/main/java/com/arangodb/internal/Communication.java
@@ -18,7 +18,7 @@ public abstract class Communication<T> {
 
 	public abstract T execute(Request request, HostHandle hostHandle);
 
-	public T handleArangoDBException(ArangoDBException e, Request request) {
+	public T handleException(ArangoDBException e, Request request) {
 		if (e instanceof ArangoDBRedirectException) {
 			try {
 				hostHandler.closeCurrentOnError();

--- a/src/main/java/com/arangodb/internal/Communication.java
+++ b/src/main/java/com/arangodb/internal/Communication.java
@@ -18,7 +18,7 @@ public abstract class Communication<T> {
 
 	public abstract T execute(Request request, HostHandle hostHandle);
 
-	public T handleException(ArangoDBException e, Request request) {
+	protected T handleException(ArangoDBException e, Request request) {
 		if (e instanceof ArangoDBRedirectException) {
 			try {
 				hostHandler.closeCurrentOnError();

--- a/src/main/java/com/arangodb/internal/Communication.java
+++ b/src/main/java/com/arangodb/internal/Communication.java
@@ -1,0 +1,37 @@
+package com.arangodb.internal;
+
+import com.arangodb.ArangoDBException;
+import com.arangodb.internal.net.ArangoDBRedirectException;
+import com.arangodb.internal.net.HostDescription;
+import com.arangodb.internal.net.HostHandle;
+import com.arangodb.internal.net.HostHandler;
+import com.arangodb.internal.util.HostUtils;
+import com.arangodb.velocystream.Request;
+
+public abstract class Communication<T> {
+
+	protected final HostHandler hostHandler;
+
+	protected Communication(HostHandler hostHandler) {
+		this.hostHandler = hostHandler;
+	}
+
+	public abstract T execute(Request request, HostHandle hostHandle);
+
+	public T handleArangoDBException(ArangoDBException e, Request request) {
+		if (e instanceof ArangoDBRedirectException) {
+			try {
+				hostHandler.closeCurrentOnError();
+			} finally {
+				hostHandler.fail();
+			}
+
+			String location = ArangoDBRedirectException.class.cast(e).getLocation();
+			HostDescription redirectHost = HostUtils.createFromLocation(location);
+			return execute(request, new HostHandle().setHost(redirectHost));
+		} else {
+			throw e;
+		}
+	}
+
+}

--- a/src/main/java/com/arangodb/internal/http/HttpCommunication.java
+++ b/src/main/java/com/arangodb/internal/http/HttpCommunication.java
@@ -100,7 +100,7 @@ public class HttpCommunication extends Communication<Response> implements Closea
 				}
 			}
 		} catch (ArangoDBException e) {
-			return handleArangoDBException(e, request);
+			return handleException(e, request);
 		} catch (IOException e) {
 			throw new ArangoDBException(e);
 		}

--- a/src/main/java/com/arangodb/internal/http/HttpProtocol.java
+++ b/src/main/java/com/arangodb/internal/http/HttpProtocol.java
@@ -22,9 +22,6 @@ package com.arangodb.internal.http;
 
 import java.io.IOException;
 
-import org.apache.http.client.ClientProtocolException;
-
-import com.arangodb.ArangoDBException;
 import com.arangodb.internal.net.CommunicationProtocol;
 import com.arangodb.internal.net.HostHandle;
 import com.arangodb.velocystream.Request;
@@ -39,19 +36,12 @@ public class HttpProtocol implements CommunicationProtocol {
 	private final HttpCommunication httpCommunitaction;
 
 	public HttpProtocol(final HttpCommunication httpCommunitaction) {
-		super();
 		this.httpCommunitaction = httpCommunitaction;
 	}
 
 	@Override
-	public Response execute(final Request request, final HostHandle hostHandle) throws ArangoDBException {
-		try {
-			return httpCommunitaction.execute(request, hostHandle);
-		} catch (final ClientProtocolException e) {
-			throw new ArangoDBException(e);
-		} catch (final IOException e) {
-			throw new ArangoDBException(e);
-		}
+	public Response execute(final Request request, final HostHandle hostHandle) {
+		return httpCommunitaction.execute(request, hostHandle);
 	}
 
 	@Override

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
@@ -130,7 +130,7 @@ public abstract class VstCommunication<R, C extends VstConnection> extends Commu
 			final C connection = connect(hostHandle, RequestUtils.determineAccessType(request));
 			return execute(request, connection);
 		} catch (ArangoDBException e) {
-			return handleArangoDBException(e, request);
+			return handleException(e, request);
 		}
 	}
 

--- a/src/test/java/com/arangodb/internal/CommunicationTest.java
+++ b/src/test/java/com/arangodb/internal/CommunicationTest.java
@@ -21,7 +21,7 @@ public class CommunicationTest {
 		HostHandler handler = EasyMock.createMock(HostHandler.class);
 		EasyMock.replay(handler);
 
-		new TrackingCommunication(handler).handleArangoDBException(new ArangoDBException(""), REQUEST);
+		new TrackingCommunication(handler).handleException(new ArangoDBException(""), REQUEST);
 	}
 
 	@Test(expected = ArangoDBException.class)
@@ -37,7 +37,7 @@ public class CommunicationTest {
 		EasyMock.replay(handler);
 
 		try {
-			new TrackingCommunication(handler).handleArangoDBException(REDIRECT_EXCEPTION, REQUEST);
+			new TrackingCommunication(handler).handleException(REDIRECT_EXCEPTION, REQUEST);
 		} finally {
 			EasyMock.verify(handler);
 		}
@@ -51,7 +51,7 @@ public class CommunicationTest {
 		EasyMock.replay(handler);
 
 		TrackingCommunication trackingCommunication = new TrackingCommunication(handler);
-		trackingCommunication.handleArangoDBException(REDIRECT_EXCEPTION, REQUEST);
+		trackingCommunication.handleException(REDIRECT_EXCEPTION, REQUEST);
 		assertTrue(trackingCommunication.isExecuted());
 	}
 

--- a/src/test/java/com/arangodb/internal/CommunicationTest.java
+++ b/src/test/java/com/arangodb/internal/CommunicationTest.java
@@ -1,0 +1,76 @@
+package com.arangodb.internal;
+
+import com.arangodb.ArangoDBException;
+import com.arangodb.internal.net.ArangoDBRedirectException;
+import com.arangodb.internal.net.HostHandle;
+import com.arangodb.internal.net.HostHandler;
+import com.arangodb.velocystream.Request;
+import com.arangodb.velocystream.RequestType;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class CommunicationTest {
+
+	private final static Request REQUEST = new Request("", RequestType.GET, "");
+	private final static ArangoDBRedirectException REDIRECT_EXCEPTION = new ArangoDBRedirectException("Test", "Location");
+
+	@Test(expected = ArangoDBException.class)
+	public void noRedirection() {
+		HostHandler handler = EasyMock.createMock(HostHandler.class);
+		EasyMock.replay(handler);
+
+		new TrackingCommunication(handler).handleArangoDBException(new ArangoDBException(""), REQUEST);
+	}
+
+	@Test(expected = ArangoDBException.class)
+	public void exceptionOnClosing() {
+		HostHandler handler = EasyMock.createMock(HostHandler.class);
+
+		handler.closeCurrentOnError();
+		EasyMock.expectLastCall().andThrow(new ArangoDBException(""));
+
+		handler.fail();
+		EasyMock.expectLastCall().once();
+
+		EasyMock.replay(handler);
+
+		try {
+			new TrackingCommunication(handler).handleArangoDBException(REDIRECT_EXCEPTION, REQUEST);
+		} finally {
+			EasyMock.verify(handler);
+		}
+	}
+
+	@Test
+	public void noExceptions() {
+		HostHandler handler = EasyMock.createMock(HostHandler.class);
+		handler.closeCurrentOnError();
+		handler.fail();
+		EasyMock.replay(handler);
+
+		TrackingCommunication trackingCommunication = new TrackingCommunication(handler);
+		trackingCommunication.handleArangoDBException(REDIRECT_EXCEPTION, REQUEST);
+		assertTrue(trackingCommunication.isExecuted());
+	}
+
+	private static class TrackingCommunication extends Communication {
+		private boolean isExecuted;
+
+		protected TrackingCommunication(HostHandler hostHandler) {
+			super(hostHandler);
+		}
+
+		public boolean isExecuted() {
+			return isExecuted;
+		}
+
+		@Override
+		public Object execute(Request request, HostHandle hostHandle) {
+			isExecuted = true;
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
Hi there,
This PR fixes HostHandler#fail method not invoked in case unchecked exception is generated in HostHandler#closeCurrentOnError method.
For example this exception can be generated in FallbackHostHandler#closeCurrentOnError -> HostImpl#closeOnError.

Also while fixing this I removed copy paste of exception handling.