### PR TITLE
Update KeyType.java

### DIFF
--- a/src/main/java/com/arangodb/entity/KeyType.java
+++ b/src/main/java/com/arangodb/entity/KeyType.java
@@ -25,5 +25,5 @@ package com.arangodb.entity;
  *
  */
 public enum KeyType {
-	traditional, autoincrement
+	traditional, autoincrement, uuid, padded
 }


### PR DESCRIPTION
addresses https://github.com/arangodb/arangodb/issues/8174 point #4:

Lastly, it doesn't yet seem the JAVA library supports the uuid and padded key generators. Is there any reason for this, or should I open an issue for it? The fix may be as simple as adding uuid and padded to the KeyType enum.