### PR TITLE
Added v3.5 TTL index

### DIFF
--- a/src/main/java/com/arangodb/entity/IndexType.java
+++ b/src/main/java/com/arangodb/entity/IndexType.java
@@ -25,5 +25,5 @@ package com.arangodb.entity;
  *
  */
 public enum IndexType {
-	primary, hash, skiplist, persistent, geo, geo1, geo2, fulltext, edge
+	primary, hash, skiplist, persistent, geo, geo1, geo2, fulltext, edge, ttl
 }


### PR DESCRIPTION
v3.5 supports [TTL indexes ](https://www.arangodb.com/arangodb-training-center/ttl-indexes/) but this is not implemented in java-driver.
