### PR TITLE
hostnameVerifier

### DIFF
--- a/src/main/java/com/arangodb/ArangoDB.java
+++ b/src/main/java/com/arangodb/ArangoDB.java
@@ -46,6 +46,7 @@ import com.arangodb.velocypack.*;
 import com.arangodb.velocystream.Request;
 import com.arangodb.velocystream.Response;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -172,6 +173,17 @@ public interface ArangoDB extends ArangoSerializationAccessor {
          */
         public Builder sslContext(final SSLContext sslContext) {
             setSslContext(sslContext);
+            return this;
+        }
+
+        /**
+         * Sets the {@link javax.net.ssl.HostnameVerifier} to be used when using ssl with http protocol.
+         *
+         * @param hostnameVerifier HostnameVerifier to be used
+         * @return {@link ArangoDB.Builder}
+         */
+        public Builder hostnameVerifier(final HostnameVerifier hostnameVerifier) {
+            setHostnameVerifier(hostnameVerifier);
             return this;
         }
 
@@ -571,8 +583,8 @@ public interface ArangoDB extends ArangoSerializationAccessor {
 
             final ConnectionFactory connectionFactory = (protocol == null || Protocol.VST == protocol)
                     ? new VstConnectionFactorySync(host, timeout, connectionTtl, useSsl, sslContext)
-                    : new HttpConnectionFactory(timeout, user, password, useSsl, sslContext, custom, protocol,
-                    connectionTtl, httpCookieSpec);
+                    : new HttpConnectionFactory(timeout, user, password, useSsl, sslContext, hostnameVerifier, custom,
+                    protocol, connectionTtl, httpCookieSpec);
 
             final Collection<Host> hostList = createHostList(max, connectionFactory);
             final HostResolver hostResolver = createHostResolver(hostList, max, connectionFactory);

--- a/src/main/java/com/arangodb/internal/InternalArangoDBBuilder.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoDBBuilder.java
@@ -34,6 +34,7 @@ import com.arangodb.velocypack.VPackParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStream;
@@ -74,6 +75,7 @@ public abstract class InternalArangoDBBuilder {
     protected Boolean useSsl;
     protected String httpCookieSpec;
     protected SSLContext sslContext;
+    protected HostnameVerifier hostnameVerifier;
     protected Integer chunksize;
     protected Integer maxConnections;
     protected Long connectionTtl;
@@ -158,6 +160,10 @@ public abstract class InternalArangoDBBuilder {
 
     protected void setSslContext(final SSLContext sslContext) {
         this.sslContext = sslContext;
+    }
+
+    protected void setHostnameVerifier(final HostnameVerifier hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
     }
 
     protected void setChunksize(final Integer chunksize) {

--- a/src/main/java/com/arangodb/internal/http/HttpConnectionFactory.java
+++ b/src/main/java/com/arangodb/internal/http/HttpConnectionFactory.java
@@ -26,6 +26,7 @@ import com.arangodb.internal.net.ConnectionFactory;
 import com.arangodb.internal.net.HostDescription;
 import com.arangodb.util.ArangoSerialization;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
 /**
@@ -36,11 +37,12 @@ public class HttpConnectionFactory implements ConnectionFactory {
     private final HttpConnection.Builder builder;
 
     public HttpConnectionFactory(final Integer timeout, final String user, final String password, final Boolean useSsl,
-                                 final SSLContext sslContext, final ArangoSerialization util, final Protocol protocol,
+                                 final SSLContext sslContext, final HostnameVerifier hostnameVerifier, final ArangoSerialization util, final Protocol protocol,
                                  final Long connectionTtl, String httpCookieSpec) {
         super();
         builder = new HttpConnection.Builder().timeout(timeout).user(user).password(password).useSsl(useSsl)
-                .sslContext(sslContext).serializationUtil(util).contentType(protocol).ttl(connectionTtl).httpCookieSpec(httpCookieSpec);
+                .sslContext(sslContext).hostnameVerifier(hostnameVerifier).serializationUtil(util).contentType(protocol)
+                .ttl(connectionTtl).httpCookieSpec(httpCookieSpec);
 
     }
 

--- a/src/test/java/com/arangodb/example/ssl/SslExample.java
+++ b/src/test/java/com/arangodb/example/ssl/SslExample.java
@@ -23,6 +23,7 @@ package com.arangodb.example.ssl;
 import com.arangodb.ArangoDB;
 import com.arangodb.Protocol;
 import com.arangodb.entity.ArangoDBVersion;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -55,6 +56,35 @@ public class SslExample {
 	@Test
 	@Ignore
 	public void connect() throws Exception {
+		final ArangoDB arangoDB = new ArangoDB.Builder()
+				.host("localhost", 8529)
+				.password("test")
+				.useSsl(true)
+				.sslContext(createSslContext())
+				.useProtocol(Protocol.HTTP_JSON)
+				.build();
+		final ArangoDBVersion version = arangoDB.getVersion();
+		assertThat(version, is(notNullValue()));
+		System.out.println(version.getVersion());
+	}
+
+	@Test
+	@Ignore
+	public void noopHostnameVerifier() throws Exception {
+		final ArangoDB arangoDB = new ArangoDB.Builder()
+				.host("127.0.0.1", 8529)
+				.password("test")
+				.useSsl(true)
+				.sslContext(createSslContext())
+				.hostnameVerifier(NoopHostnameVerifier.INSTANCE)
+				.useProtocol(Protocol.HTTP_JSON)
+				.build();
+		final ArangoDBVersion version = arangoDB.getVersion();
+		assertThat(version, is(notNullValue()));
+		System.out.println(version.getVersion());
+	}
+
+	private SSLContext createSslContext() throws Exception {
 		final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
 		ks.load(this.getClass().getResourceAsStream(SSL_TRUSTSTORE), SSL_TRUSTSTORE_PASSWORD.toCharArray());
 
@@ -67,17 +97,7 @@ public class SslExample {
 		final SSLContext sc = SSLContext.getInstance("TLS");
 		sc.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
 
-
-		final ArangoDB arangoDB = new ArangoDB.Builder()
-				.host("127.0.0.1", 8529)
-				.password("test")
-				.useSsl(true)
-				.sslContext(sc)
-				.useProtocol(Protocol.HTTP_JSON)
-				.build();
-		final ArangoDBVersion version = arangoDB.getVersion();
-		assertThat(version, is(notNullValue()));
-		System.out.println(version.getVersion());
+		return sc;
 	}
 
 }


### PR DESCRIPTION
Added hostnameVerifier in driver builder to allow customizing hostname verification, eg. skipping it in dev/test environments.

fixes https://github.com/arangodb/arangodb-java-driver/issues/341
