### PR TITLE
Deprecated ArangoIterable methods in favour of Java 8 Stream equivalents

### DIFF
--- a/src/main/java/com/arangodb/ArangoIterable.java
+++ b/src/main/java/com/arangodb/ArangoIterable.java
@@ -21,6 +21,7 @@
 package com.arangodb;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * @author Mark Vollmary
@@ -30,43 +31,60 @@ public interface ArangoIterable<T> extends Iterable<T> {
     @Override
     ArangoIterator<T> iterator();
 
+    Stream<T> stream();
+
     /**
      * Performs the given action for each element of the {@code ArangoIterable}
      *
-     * @param action a action to perform on the elements
+     * @param action
+     *         a action to perform on the elements
+     * @deprecated Use {@link #forEach(java.util.function.Consumer)} instead.
      */
+    @Deprecated
     void foreach(Consumer<? super T> action);
 
     /**
      * Returns a {@code ArangoIterable} consisting of the results of applying the given function to the elements of this
      * {@code ArangoIterable}.
      *
-     * @param mapper a function to apply to each element
+     * @param mapper
+     *         a function to apply to each element
      * @return the new {@code ArangoIterable}
+     *
+     * @deprecated Use {@link #stream()} and {@link Stream#map(java.util.function.Function)} instead.
      */
+    @Deprecated
     <R> ArangoIterable<R> map(Function<? super T, ? extends R> mapper);
 
     /**
      * Returns a {@code ArangoIterable} consisting of the elements of this {@code ArangoIterable} that match the given
      * predicate.
      *
-     * @param predicate a predicate to apply to each element to determine if it should be included
+     * @param predicate
+     *         a predicate to apply to each element to determine if it should be included
      * @return the new {@code ArangoIterable}
+     *
+     * @deprecated Use {@link #stream()} and {@link Stream#filter(java.util.function.Predicate)} instead.
      */
+    @Deprecated
     ArangoIterable<T> filter(Predicate<? super T> predicate);
 
     /**
      * Returns the first element or {@code null} if no element exists.
      *
      * @return first element or {@code null}
+     * @deprecated Use {@link #stream()} and {@link Stream#findFirst()} instead.
      */
+    @Deprecated
     T first();
 
     /**
      * Returns the count of elements of this {@code ArangoIterable}.
      *
      * @return the count of elements
+     * @deprecated Use {@link #stream()} and {@link Stream#count()} instead.
      */
+    @Deprecated
     long count();
 
     /**
@@ -75,7 +93,9 @@ public interface ArangoIterable<T> extends Iterable<T> {
      * @param predicate a predicate to apply to elements of this {@code ArangoIterable}
      * @return {@code true} if any elements of the {@code ArangoIterable} match the provided predicate, otherwise
      * {@code false}
+     * @deprecated Use {@link #stream()} and {@link Stream#anyMatch(java.util.function.Predicate)} instead.
      */
+    @Deprecated
     boolean anyMatch(Predicate<? super T> predicate);
 
     /**
@@ -84,7 +104,9 @@ public interface ArangoIterable<T> extends Iterable<T> {
      * @param predicate a predicate to apply to elements of this {@code ArangoIterable}
      * @return {@code true} if all elements of the {@code ArangoIterable} match the provided predicate, otherwise
      * {@code false}
+     * @deprecated Use {@link #stream()} and {@link Stream#allMatch(java.util.function.Predicate)} instead.
      */
+    @Deprecated
     boolean allMatch(Predicate<? super T> predicate);
 
     /**
@@ -93,7 +115,9 @@ public interface ArangoIterable<T> extends Iterable<T> {
      * @param predicate a predicate to apply to elements of this {@code ArangoIterable}
      * @return {@code true} if no elements of the {@code ArangoIterable} match the provided predicate, otherwise
      * {@code false}
+     * @deprecated Use {@link #stream()} and {@link Stream#noneMatch(java.util.function.Predicate)} instead.
      */
+    @Deprecated
     boolean noneMatch(Predicate<? super T> predicate);
 
     /**
@@ -101,7 +125,9 @@ public interface ArangoIterable<T> extends Iterable<T> {
      *
      * @param target the collection to insert into
      * @return the filled target
+     * @deprecated Use {@link #stream()} and {@link Stream#collect} instead.
      */
+    @Deprecated
     <R extends Collection<? super T>> R collectInto(R target);
 
 }

--- a/src/main/java/com/arangodb/Consumer.java
+++ b/src/main/java/com/arangodb/Consumer.java
@@ -23,7 +23,9 @@ package com.arangodb;
 /**
  * @param <T> the type of the input to the operation
  * @author Mark Vollmary
+ * @deprecated Use {@link java.util.function.Consumer} instead.
  */
+@Deprecated
 public interface Consumer<T> {
 
     /**

--- a/src/main/java/com/arangodb/Predicate.java
+++ b/src/main/java/com/arangodb/Predicate.java
@@ -23,7 +23,9 @@ package com.arangodb;
 /**
  * @param <T> the type of the input to the predicate
  * @author Mark Vollmary
+ * @deprecated Use {@link java.util.function.Predicate} instead.
  */
+@Deprecated
 public interface Predicate<T> {
 
     /**

--- a/src/main/java/com/arangodb/internal/cursor/AbstractArangoIterable.java
+++ b/src/main/java/com/arangodb/internal/cursor/AbstractArangoIterable.java
@@ -27,11 +27,18 @@ import com.arangodb.Predicate;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Mark Vollmary
  */
 public abstract class AbstractArangoIterable<T> implements ArangoIterable<T> {
+
+    @Override
+    public Stream<T> stream() {
+        return StreamSupport.stream(spliterator(), false);
+    }
 
     @Override
     public <R> ArangoIterable<R> map(final Function<? super T, ? extends R> mapper) {

--- a/src/main/java/com/arangodb/internal/cursor/ArangoFilterIterable.java
+++ b/src/main/java/com/arangodb/internal/cursor/ArangoFilterIterable.java
@@ -28,6 +28,7 @@ import com.arangodb.Predicate;
 /**
  * @author Mark Vollmary
  */
+@Deprecated
 public class ArangoFilterIterable<T> extends AbstractArangoIterable<T> implements ArangoIterable<T> {
 
     private final ArangoIterable<T> iterable;

--- a/src/main/java/com/arangodb/internal/cursor/ArangoMappingIterable.java
+++ b/src/main/java/com/arangodb/internal/cursor/ArangoMappingIterable.java
@@ -28,6 +28,7 @@ import com.arangodb.Function;
 /**
  * @author Mark Vollmary
  */
+@Deprecated
 public class ArangoMappingIterable<R, T> extends AbstractArangoIterable<T> implements ArangoIterable<T> {
 
     private final ArangoIterable<R> iterable;


### PR DESCRIPTION
fixes https://github.com/arangodb/arangodb-java-driver/issues/379