### PR TITLE
arangodb-java-driver-384 "java.net.SocketException: Socket closed"

### DIFF
--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
@@ -94,7 +94,6 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
                     hostHandler.confirm();
                     if (!connection.isOpen()) {
                         // see https://github.com/arangodb/arangodb-java-driver/issues/384
-                        connection.close();
                         hostHandler.fail();
                         host = hostHandler.get(hostHandle, accessType);
                         continue;

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
@@ -92,6 +92,13 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
                         tryAuthenticate(connection);
                     }
                     hostHandler.confirm();
+                    if (!connection.isOpen()) {
+                        // see https://github.com/arangodb/arangodb-java-driver/issues/384
+                        connection.close();
+                        hostHandler.fail();
+                        host = hostHandler.get(hostHandle, accessType);
+                        continue;
+                    }
                     return connection;
                 } catch (final IOException e) {
                     hostHandler.fail();


### PR DESCRIPTION
fixes #384 

Before returning a connection instance to the caller of the `connect()` method, check if the connection obtained from the host handler is still alive (i.e. is the associated socket is open), otherwise discard it and get a new one until a usable connection is found.