### PR TITLE
fixed exceptions handling during shutdown

### DIFF
--- a/src/main/java/com/arangodb/async/internal/ArangoDBAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoDBAsyncImpl.java
@@ -82,9 +82,12 @@ public class ArangoDBAsyncImpl extends InternalArangoDB<ArangoExecutorAsync> imp
     public void shutdown() throws ArangoDBException {
         try {
             executor.disconnect();
-            cp.close();
-        } catch (final IOException e) {
-            throw new ArangoDBException(e);
+        } finally {
+            try {
+                cp.close();
+            } catch (final IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/com/arangodb/async/internal/ArangoDBAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoDBAsyncImpl.java
@@ -40,6 +40,8 @@ import com.arangodb.model.UserCreateOptions;
 import com.arangodb.model.UserUpdateOptions;
 import com.arangodb.velocystream.Request;
 import com.arangodb.velocystream.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -49,6 +51,8 @@ import java.util.concurrent.CompletableFuture;
  * @author Mark Vollmary
  */
 public class ArangoDBAsyncImpl extends InternalArangoDB<ArangoExecutorAsync> implements ArangoDBAsync {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArangoDBAsyncImpl.class);
 
     private final CommunicationProtocol cp;
 
@@ -86,7 +90,7 @@ public class ArangoDBAsyncImpl extends InternalArangoDB<ArangoExecutorAsync> imp
             try {
                 cp.close();
             } catch (final IOException e) {
-                e.printStackTrace();
+                LOGGER.error("Got exception during shutdown:", e);
             }
         }
     }

--- a/src/main/java/com/arangodb/async/internal/ArangoExecutorAsync.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoExecutorAsync.java
@@ -20,6 +20,7 @@
 
 package com.arangodb.async.internal;
 
+import com.arangodb.ArangoDBException;
 import com.arangodb.async.internal.velocystream.VstCommunicationAsync;
 import com.arangodb.internal.ArangoExecutor;
 import com.arangodb.internal.DocumentCache;
@@ -70,8 +71,12 @@ public class ArangoExecutorAsync extends ArangoExecutor {
                 .thenApplyAsync(responseDeserializer::deserialize);
     }
 
-    public void disconnect() throws IOException {
-        communication.close();
-        outgoingExecutor.shutdown();
+    public void disconnect() {
+        try {
+            communication.close();
+            outgoingExecutor.shutdown();
+        } catch (final IOException e) {
+            throw new ArangoDBException(e);
+        }
     }
 }

--- a/src/main/java/com/arangodb/async/internal/ArangoExecutorAsync.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoExecutorAsync.java
@@ -74,9 +74,10 @@ public class ArangoExecutorAsync extends ArangoExecutor {
     public void disconnect() {
         try {
             communication.close();
-            outgoingExecutor.shutdown();
         } catch (final IOException e) {
             throw new ArangoDBException(e);
+        } finally {
+            outgoingExecutor.shutdown();
         }
     }
 }

--- a/src/main/java/com/arangodb/internal/ArangoDBImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoDBImpl.java
@@ -118,7 +118,7 @@ public class ArangoDBImpl extends InternalArangoDB<ArangoExecutorSync> implement
             try {
                 cp.close();
             } catch (final IOException e) {
-                e.printStackTrace();
+                LOGGER.error("Got exception during shutdown:", e);
             }
         }
     }

--- a/src/main/java/com/arangodb/internal/ArangoDBImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoDBImpl.java
@@ -114,9 +114,12 @@ public class ArangoDBImpl extends InternalArangoDB<ArangoExecutorSync> implement
     public void shutdown() throws ArangoDBException {
         try {
             executor.disconnect();
-            cp.close();
-        } catch (final IOException e) {
-            throw new ArangoDBException(e);
+        } finally {
+            try {
+                cp.close();
+            } catch (final IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/com/arangodb/internal/net/FallbackHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/FallbackHostHandler.java
@@ -34,11 +34,13 @@ public class FallbackHostHandler implements HostHandler {
     private Host lastSuccess;
     private int iterations;
     private boolean firstOpened;
+    private HostSet hosts;
 
     public FallbackHostHandler(final HostResolver resolver) {
         this.resolver = resolver;
         iterations = 0;
-        current = lastSuccess = resolver.resolve(true, false).getHostsList().get(0);
+        hosts = resolver.resolve(true, false);
+        current = lastSuccess = hosts.getHostsList().get(0);
         firstOpened = true;
     }
 
@@ -60,10 +62,11 @@ public class FallbackHostHandler implements HostHandler {
 
     @Override
     public void fail() {
-        final List<Host> hosts = resolver.resolve(false, false).getHostsList();
-        final int index = hosts.indexOf(current) + 1;
-        final boolean inBound = index < hosts.size();
-        current = hosts.get(inBound ? index : 0);
+        hosts = resolver.resolve(false, false);
+        final List<Host> hostList = hosts.getHostsList();
+        final int index = hostList.indexOf(current) + 1;
+        final boolean inBound = index < hostList.size();
+        current = hostList.get(inBound ? index : 0);
         if (!inBound) {
             iterations++;
         }
@@ -78,14 +81,13 @@ public class FallbackHostHandler implements HostHandler {
     public void confirm() {
         if (firstOpened) {
             // after first successful established connection, update host list
-            resolver.resolve(false, false);
+            hosts = resolver.resolve(false, false);
             firstOpened = false;
         }
     }
 
     @Override
     public void close() {
-        final HostSet hosts = resolver.resolve(false, false);
         hosts.close();
     }
 

--- a/src/main/java/com/arangodb/internal/net/RandomHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RandomHostHandler.java
@@ -31,6 +31,7 @@ public class RandomHostHandler implements HostHandler {
     private final HostResolver resolver;
     private final HostHandler fallback;
     private Host current;
+    private HostSet hosts;
 
     public RandomHostHandler(final HostResolver resolver, final HostHandler fallback) {
         super();
@@ -59,9 +60,10 @@ public class RandomHostHandler implements HostHandler {
     }
 
     private Host getRandomHost(final boolean initial, final boolean closeConnections) {
-        final ArrayList<Host> hosts = new ArrayList<>(resolver.resolve(initial, closeConnections).getHostsList());
-        Collections.shuffle(hosts);
-        return hosts.get(0);
+        hosts = resolver.resolve(initial, closeConnections);
+        final ArrayList<Host> hostList = new ArrayList<>(hosts.getHostsList());
+        Collections.shuffle(hostList);
+        return hostList.get(0);
     }
 
     @Override
@@ -75,7 +77,6 @@ public class RandomHostHandler implements HostHandler {
 
     @Override
     public void close() {
-        final HostSet hosts = resolver.resolve(false, false);
         hosts.close();
     }
 

--- a/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
@@ -28,23 +28,22 @@ import com.arangodb.ArangoDBException;
 public class RoundRobinHostHandler implements HostHandler {
 
     private final HostResolver resolver;
-
     private int current;
     private int fails;
     private Host currentHost;
+    private HostSet hosts;
 
     public RoundRobinHostHandler(final HostResolver resolver) {
         super();
         this.resolver = resolver;
-        resolver.resolve(true, false);
+        hosts = resolver.resolve(true, false);
         current = 0;
         fails = 0;
     }
 
     @Override
     public Host get(final HostHandle hostHandle, AccessType accessType) {
-
-        final HostSet hosts = resolver.resolve(false, false);
+        hosts = resolver.resolve(false, false);
         final int size = hosts.getHostsList().size();
 
         if (fails > size) {
@@ -92,7 +91,6 @@ public class RoundRobinHostHandler implements HostHandler {
 
     @Override
     public void close() {
-        final HostSet hosts = resolver.resolve(false, false);
         hosts.close();
     }
 


### PR DESCRIPTION
Improved exception handling during shutdown by:
- removing requests to acquire the host list before shutdown and caching the last acquire host list
- closing connections in finally block

fixes #399 