### PR TITLE
Fixed deserializing null String

### DIFF
--- a/src/main/java/com/arangodb/internal/util/ArangoDeserializerImpl.java
+++ b/src/main/java/com/arangodb/internal/util/ArangoDeserializerImpl.java
@@ -48,7 +48,7 @@ public class ArangoDeserializerImpl implements ArangoDeserializer {
     public <T> T deserialize(final VPackSlice vpack, final Type type) throws ArangoDBException {
         try {
             final T doc;
-            if (type == String.class && !vpack.isString()) {
+            if (type == String.class && !vpack.isString() && !vpack.isNull()) {
                 doc = (T) vpackParser.toJson(vpack, true);
             } else {
                 doc = vpacker.deserialize(vpack, type);

--- a/src/main/java/com/arangodb/mapping/ArangoJack.java
+++ b/src/main/java/com/arangodb/mapping/ArangoJack.java
@@ -154,7 +154,7 @@ public class ArangoJack implements ArangoSerialization {
     public <T> T deserialize(final VPackSlice vpack, final Type type) throws ArangoDBException {
         try {
             final T doc;
-            if (type == String.class && !vpack.isString()) {
+            if (type == String.class && !vpack.isString() && !vpack.isNull()) {
                 final JsonNode node = vpackMapper.readTree(
                         Arrays.copyOfRange(vpack.getBuffer(), vpack.getStart(), vpack.getStart() + vpack.getByteSize()));
                 doc = (T) jsonMapper.writeValueAsString(node);

--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -700,7 +700,7 @@ public class ArangoDatabaseTest extends BaseTest {
     public void queryWithFailOnWarningFalse() {
         final ArangoCursor<String> cursor = db
                 .query("RETURN 1 / 0", null, new AqlQueryOptions().failOnWarning(false), String.class);
-        assertThat(cursor.next(), is("null"));
+        assertThat(cursor.next(), nullValue());
     }
 
     @Test

--- a/src/test/java/com/arangodb/serde/CustomSerdeTest.java
+++ b/src/test/java/com/arangodb/serde/CustomSerdeTest.java
@@ -28,6 +28,7 @@ import com.arangodb.entity.BaseDocument;
 import com.arangodb.mapping.ArangoJack;
 import com.arangodb.model.DocumentCreateOptions;
 import com.arangodb.util.ArangoSerialization;
+import com.arangodb.velocypack.VPackBuilder;
 import com.arangodb.velocypack.VPackSlice;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -53,7 +54,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.USE_BIG_INTE
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 
 /**
@@ -232,6 +233,12 @@ public class CustomSerdeTest {
         assertThat(result.getAttribute("arr"), is("hello"));
         assertThat(result.getAttribute("int"), instanceOf(BigInteger.class));
         assertThat(result.getAttribute("int"), is(BigInteger.valueOf(10)));
+    }
+
+    @Test
+    public void parseNullString() {
+        final String json = arangoDB.util(CUSTOM).deserialize(new VPackBuilder().add((String) null).slice(), String.class);
+        assertThat(json, nullValue());
     }
 
 }

--- a/src/test/java/com/arangodb/util/ArangoSerializationTest.java
+++ b/src/test/java/com/arangodb/util/ArangoSerializationTest.java
@@ -22,10 +22,7 @@ package com.arangodb.util;
 
 import com.arangodb.ArangoDB;
 import com.arangodb.entity.BaseDocument;
-import com.arangodb.velocypack.Type;
-import com.arangodb.velocypack.VPackBuilder;
-import com.arangodb.velocypack.VPackSlice;
-import com.arangodb.velocypack.ValueType;
+import com.arangodb.velocypack.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -36,6 +33,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * @author Mark Vollmary
@@ -102,4 +100,11 @@ public class ArangoSerializationTest {
         final String json = util.deserialize(util.serialize(entity, new ArangoSerializer.Options()), String.class);
         assertThat(json, is("{\"value\":[\"test\",null]}"));
     }
+
+    @Test
+    public void parseNullString() {
+        final String json = util.deserialize(new VPackBuilder().add((String) null).slice(), String.class);
+        assertThat(json, nullValue());
+    }
+
 }


### PR DESCRIPTION
When deserializing to String, if the VPack content is not a VPack String, it is deserialized as json string.
This PR exclude the additional case of VPack null value, so that deserializing a VPack null value as String will produce `null` instead of `"null"`.