### PR TITLE
set max 3 retries for active failover redirects

### DIFF
--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
@@ -138,11 +138,17 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
     }
 
     public R execute(final Request request, final HostHandle hostHandle) throws ArangoDBException {
+        return execute(request, hostHandle, 0);
+    }
+
+    protected R execute(final Request request, final HostHandle hostHandle, final int attemptCount) throws ArangoDBException {
         final C connection = connect(hostHandle, RequestUtils.determineAccessType(request));
-        return execute(request, connection);
+        return execute(request, connection, attemptCount);
     }
 
     protected abstract R execute(final Request request, C connection) throws ArangoDBException;
+
+    protected abstract R execute(final Request request, C connection, final int attemptCount) throws ArangoDBException;
 
     protected void checkError(final Response response) throws ArangoDBException {
         ResponseUtils.checkError(util, response);


### PR DESCRIPTION
This PR prevents `StackOverflowError` by setting a max amount of retries for following active failover redirects.

---
fixes https://github.com/arangodb/arangodb-java-driver/issues/409