### PR TITLE
[DE-79] logging API enhancements

### DIFF
--- a/src/main/java/com/arangodb/entity/LogLevelEntity.java
+++ b/src/main/java/com/arangodb/entity/LogLevelEntity.java
@@ -29,6 +29,7 @@ public class LogLevelEntity implements Entity {
         FATAL, ERROR, WARNING, INFO, DEBUG, TRACE, DEFAULT
     }
 
+    private LogLevel all;
     private LogLevel agency;
     private LogLevel agencycomm;
     private LogLevel cluster;
@@ -50,6 +51,10 @@ public class LogLevelEntity implements Entity {
 
     public LogLevelEntity() {
         super();
+    }
+
+    public void setAll(final LogLevel all) {
+        this.all = all;
     }
 
     public LogLevel getAgency() {

--- a/src/test/java/com/arangodb/ArangoDBTest.java
+++ b/src/test/java/com/arangodb/ArangoDBTest.java
@@ -645,6 +645,29 @@ public class ArangoDBTest {
     }
 
     @Test
+    public void setAllLogLevel() {
+        assumeTrue(isAtLeastVersion(3, 9));
+        final LogLevelEntity entity = new LogLevelEntity();
+        try {
+            entity.setAll(LogLevelEntity.LogLevel.ERROR);
+            final LogLevelEntity logLevel = arangoDB.setLogLevel(entity);
+            assertThat(logLevel, is(notNullValue()));
+            assertThat(logLevel.getAgency(), is(LogLevelEntity.LogLevel.ERROR));
+            assertThat(logLevel.getAgency(), is(LogLevelEntity.LogLevel.ERROR));
+
+            LogLevelEntity retrievedLevels = arangoDB.getLogLevel();
+            assertThat(retrievedLevels.getAgency(), is(LogLevelEntity.LogLevel.ERROR));
+            assertThat(retrievedLevels.getAgency(), is(LogLevelEntity.LogLevel.ERROR));
+
+            assertThat(logLevel.getAgency(), is(LogLevelEntity.LogLevel.ERROR));
+            assertThat(logLevel.getQueries(), is(LogLevelEntity.LogLevel.ERROR));
+        } finally {
+            entity.setAll(LogLevelEntity.LogLevel.INFO);
+            arangoDB.setLogLevel(entity);
+        }
+    }
+
+    @Test
     public void arangoDBException() {
         try {
             arangoDB.db("no").getInfo();


### PR DESCRIPTION
https://arangodb.atlassian.net/browse/DE-79

The HTTP REST API endpoint PUT /_admin/log/level can now handle the pseudo log topic "all". Setting the log level for the "all" log topic will adjust the log level for all existing log topics. For example, sending the JSON object to this API

{"all":"debug"}

will set all log topics to log level "debug".

 