### PR TITLE
[DE-120] Bugfix swallowing connection exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.arangodb</groupId>
     <artifactId>arangodb-java-driver</artifactId>
-    <version>6.14.0</version>
+    <version>6.15.0-SNAPSHOT</version>
     <inceptionYear>2016</inceptionYear>
     <packaging>jar</packaging>
 

--- a/src/main/java/com/arangodb/ArangoDBException.java
+++ b/src/main/java/com/arangodb/ArangoDBException.java
@@ -56,6 +56,12 @@ public class ArangoDBException extends RuntimeException {
         this.responseCode = null;
     }
 
+    public ArangoDBException(final String message, final Throwable cause) {
+        super(message, cause);
+        this.entity = null;
+        this.responseCode = null;
+    }
+
     /**
      * @return ArangoDB error message
      */

--- a/src/main/java/com/arangodb/ArangoDBMultipleException.java
+++ b/src/main/java/com/arangodb/ArangoDBMultipleException.java
@@ -1,0 +1,44 @@
+package com.arangodb;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class ArangoDBMultipleException extends RuntimeException {
+
+    private final List<Throwable> exceptions;
+
+    public ArangoDBMultipleException(List<Throwable> exceptions) {
+        super();
+        this.exceptions = exceptions;
+    }
+
+    public List<Throwable> getExceptions() {
+        return exceptions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ArangoDBMultipleException that = (ArangoDBMultipleException) o;
+        return Objects.equals(exceptions, that.exceptions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(exceptions);
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner("\n\t", "ArangoDBMultipleException{\n\t", "\n}");
+        for (Throwable t : exceptions) {
+            StringJoiner tJoiner = new StringJoiner("\n\t\t", "\n\t\t", "");
+            for (StackTraceElement stackTraceElement : t.getStackTrace())
+                tJoiner.add("at " + stackTraceElement);
+            joiner.add(t + tJoiner.toString());
+        }
+        return joiner.toString();
+    }
+}

--- a/src/main/java/com/arangodb/async/internal/velocystream/VstCommunicationAsync.java
+++ b/src/main/java/com/arangodb/async/internal/velocystream/VstCommunicationAsync.java
@@ -85,7 +85,7 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
                         final String location = e.getLocation();
                         final HostDescription redirectHost = HostUtils.createFromLocation(location);
                         hostHandler.closeCurrentOnError();
-                        hostHandler.fail();
+                        hostHandler.fail(e);
                         execute(request, new HostHandle().setHost(redirectHost), attemptCount + 1)
                                 .whenComplete((v, err) -> {
                                     if (v != null) {

--- a/src/main/java/com/arangodb/internal/http/HttpCommunication.java
+++ b/src/main/java/com/arangodb/internal/http/HttpCommunication.java
@@ -87,7 +87,7 @@ public class HttpCommunication implements Closeable {
                     hostHandler.confirm();
                     return response;
                 } catch (final SocketException se) {
-                    hostHandler.fail();
+                    hostHandler.fail(se);
                     if (hostHandle != null && hostHandle.getHost() != null) {
                         hostHandle.setHost(null);
                     }
@@ -107,7 +107,7 @@ public class HttpCommunication implements Closeable {
                 final String location = ((ArangoDBRedirectException) e).getLocation();
                 final HostDescription redirectHost = HostUtils.createFromLocation(location);
                 hostHandler.closeCurrentOnError();
-                hostHandler.fail();
+                hostHandler.fail(e);
                 return execute(request, new HostHandle().setHost(redirectHost), attemptCount + 1);
             } else {
                 throw e;

--- a/src/main/java/com/arangodb/internal/http/HttpCommunication.java
+++ b/src/main/java/com/arangodb/internal/http/HttpCommunication.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.SocketException;
 
 /**
  * @author Mark Vollmary
@@ -71,11 +70,11 @@ public class HttpCommunication implements Closeable {
         hostHandler.close();
     }
 
-    public Response execute(final Request request, final HostHandle hostHandle) throws ArangoDBException, IOException {
+    public Response execute(final Request request, final HostHandle hostHandle) throws ArangoDBException {
         return execute(request, hostHandle, 0);
     }
 
-    private Response execute(final Request request, final HostHandle hostHandle, final int attemptCount) throws ArangoDBException, IOException {
+    private Response execute(final Request request, final HostHandle hostHandle, final int attemptCount) throws ArangoDBException {
         final AccessType accessType = RequestUtils.determineAccessType(request);
         Host host = hostHandler.get(hostHandle, accessType);
         try {
@@ -86,19 +85,20 @@ public class HttpCommunication implements Closeable {
                     hostHandler.success();
                     hostHandler.confirm();
                     return response;
-                } catch (final SocketException se) {
-                    hostHandler.fail(se);
+                } catch (final IOException e) {
+                    hostHandler.fail(e);
                     if (hostHandle != null && hostHandle.getHost() != null) {
                         hostHandle.setHost(null);
                     }
                     final Host failedHost = host;
                     host = hostHandler.get(hostHandle, accessType);
                     if (host != null) {
-                        LOGGER.warn(String.format("Could not connect to %s", failedHost.getDescription()), se);
+                        LOGGER.warn(String.format("Could not connect to %s", failedHost.getDescription()), e);
                         LOGGER.warn(String.format("Could not connect to %s. Try connecting to %s",
                                 failedHost.getDescription(), host.getDescription()));
                     } else {
-                        throw se;
+                        LOGGER.error(e.getMessage(), e);
+                        throw new ArangoDBException(e);
                     }
                 }
             }

--- a/src/main/java/com/arangodb/internal/http/HttpProtocol.java
+++ b/src/main/java/com/arangodb/internal/http/HttpProtocol.java
@@ -42,11 +42,7 @@ public class HttpProtocol implements CommunicationProtocol {
 
     @Override
     public Response execute(final Request request, final HostHandle hostHandle) throws ArangoDBException {
-        try {
-            return httpCommunitaction.execute(request, hostHandle);
-        } catch (final IOException e) {
-            throw new ArangoDBException(e);
-        }
+        return httpCommunitaction.execute(request, hostHandle);
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/net/DirtyReadHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/DirtyReadHostHandler.java
@@ -56,8 +56,8 @@ public class DirtyReadHostHandler implements HostHandler {
     }
 
     @Override
-    public void fail() {
-        determineHostHandler().fail();
+    public void fail(Exception exception) {
+        determineHostHandler().fail(exception);
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/net/FallbackHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/FallbackHostHandler.java
@@ -21,7 +21,9 @@
 package com.arangodb.internal.net;
 
 import com.arangodb.ArangoDBException;
+import com.arangodb.ArangoDBMultipleException;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -33,12 +35,14 @@ public class FallbackHostHandler implements HostHandler {
     private Host current;
     private Host lastSuccess;
     private int iterations;
+    private final List<Throwable> lastFailExceptions;
     private boolean firstOpened;
     private HostSet hosts;
 
     public FallbackHostHandler(final HostResolver resolver) {
         this.resolver = resolver;
-        iterations = 0;
+        lastFailExceptions = new ArrayList<>();
+        reset();
         hosts = resolver.resolve(true, false);
         current = lastSuccess = hosts.getHostsList().get(0);
         firstOpened = true;
@@ -49,19 +53,21 @@ public class FallbackHostHandler implements HostHandler {
         if (current != lastSuccess || iterations < 3) {
             return current;
         } else {
+            ArangoDBException e = new ArangoDBException("Cannot contact any host!",
+                    new ArangoDBMultipleException(new ArrayList<>(lastFailExceptions)));
             reset();
-            throw new ArangoDBException("Cannot contact any host!");
+            throw e;
         }
     }
 
     @Override
     public void success() {
         lastSuccess = current;
-        iterations = 0;
+        reset();
     }
 
     @Override
-    public void fail() {
+    public void fail(Exception exception) {
         hosts = resolver.resolve(false, false);
         final List<Host> hostList = hosts.getHostsList();
         final int index = hostList.indexOf(current) + 1;
@@ -70,11 +76,13 @@ public class FallbackHostHandler implements HostHandler {
         if (!inBound) {
             iterations++;
         }
+        lastFailExceptions.add(exception);
     }
 
     @Override
     public void reset() {
         iterations = 0;
+        lastFailExceptions.clear();
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/net/HostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/HostHandler.java
@@ -31,7 +31,7 @@ public interface HostHandler {
 
     void success();
 
-    void fail();
+    void fail(Exception exception);
 
     void reset();
 

--- a/src/main/java/com/arangodb/internal/net/RandomHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RandomHostHandler.java
@@ -54,8 +54,8 @@ public class RandomHostHandler implements HostHandler {
     }
 
     @Override
-    public void fail() {
-        fallback.fail();
+    public void fail(Exception exception) {
+        fallback.fail(exception);
         current = fallback.get(null, null);
     }
 

--- a/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
@@ -21,6 +21,10 @@
 package com.arangodb.internal.net;
 
 import com.arangodb.ArangoDBException;
+import com.arangodb.ArangoDBMultipleException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Mark Vollmary
@@ -30,15 +34,17 @@ public class RoundRobinHostHandler implements HostHandler {
     private final HostResolver resolver;
     private int current;
     private int fails;
+    private final List<Exception> lastFailExceptions;
     private Host currentHost;
     private HostSet hosts;
 
     public RoundRobinHostHandler(final HostResolver resolver) {
         super();
         this.resolver = resolver;
+        lastFailExceptions = new ArrayList<>();
         hosts = resolver.resolve(true, false);
         current = 0;
-        fails = 0;
+        reset();
     }
 
     @Override
@@ -47,8 +53,10 @@ public class RoundRobinHostHandler implements HostHandler {
         final int size = hosts.getHostsList().size();
 
         if (fails > size) {
+            ArangoDBException e = new ArangoDBException("Cannot contact any host!",
+                    new ArangoDBMultipleException(new ArrayList<>(lastFailExceptions)));
             reset();
-            throw new ArangoDBException("Cannot contact any host!");
+            throw e;
         }
 
         final int index = (current++) % size;
@@ -72,17 +80,19 @@ public class RoundRobinHostHandler implements HostHandler {
 
     @Override
     public void success() {
-        fails = 0;
+        reset();
     }
 
     @Override
-    public void fail() {
+    public void fail(Exception exception) {
         fails++;
+        lastFailExceptions.add(exception);
     }
 
     @Override
     public void reset() {
         fails = 0;
+        lastFailExceptions.clear();
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
@@ -95,13 +95,13 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
                     hostHandler.confirm();
                     if (!connection.isOpen()) {
                         // see https://github.com/arangodb/arangodb-java-driver/issues/384
-                        hostHandler.fail();
+                        hostHandler.fail(new IOException("The connection is closed."));
                         host = hostHandler.get(hostHandle, accessType);
                         continue;
                     }
                     return connection;
                 } catch (final IOException e) {
-                    hostHandler.fail();
+                    hostHandler.fail(e);
                     if (hostHandle != null && hostHandle.getHost() != null) {
                         hostHandle.setHost(null);
                     }

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
@@ -143,7 +143,7 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
             final String location = e.getLocation();
             final HostDescription redirectHost = HostUtils.createFromLocation(location);
             hostHandler.closeCurrentOnError();
-            hostHandler.fail();
+            hostHandler.fail(e);
             return execute(request, new HostHandle().setHost(redirectHost), attemptCount + 1);
         }
     }

--- a/src/test/java/com/arangodb/ArangoSslTest.java
+++ b/src/test/java/com/arangodb/ArangoSslTest.java
@@ -29,10 +29,10 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.TrustManagerFactory;
 import java.security.KeyStore;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.fail;
 
 /**
@@ -84,7 +84,9 @@ public class ArangoSslTest {
             arangoDB.getVersion();
             fail("this should fail");
         } catch (final ArangoDBException ex) {
-            assertThat(ex.getCause() instanceof SSLHandshakeException, is(true));
+            assertThat(ex.getCause(), is(instanceOf(ArangoDBMultipleException.class)));
+            List<Throwable> exceptions = ((ArangoDBMultipleException) ex.getCause()).getExceptions();
+            exceptions.forEach(e -> assertThat(e, is(instanceOf(SSLHandshakeException.class))));
         }
     }
 


### PR DESCRIPTION
On connection error, the cause exception(s) should not be swallowed. 
This PR adds such exceptions to the main exception thrown to the caller.

Related resiliency tests: https://github.com/rashtao/arangodb-java-driver-resiliency-tests/commit/62fe973567d787ae9ce5830eb2a00066676d495a

The cases to test are:
- [x] name resolution errors (i.e. `UnknownHostException`)
- [x] socket errors (i.e. `ConnectException`)
- [x] TLS setup errors (i.e. `SSLHandshakeException`) 