### PR TITLE
[DE-69] jwt authentication

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -117,7 +117,10 @@ jobs:
           restore-keys: ${{ runner.os }}-maven-
       - name: Set JWT
         run: |
-          JWT=$(curl "http://172.17.0.1:8529/_db/_system/_open/auth" -X POST -d '{"username":"root","password":"test"}' | jq ".jwt" | xargs)
+          ENDPOINT=$(./docker/find_active_endpoint.sh)
+          echo "Active endpoint: $ENDPOINT"
+          JWT=$(curl "http://$ENDPOINT/_db/_system/_open/auth" -X POST -d '{"username":"root","password":"test"}' | jq ".jwt" | xargs)
+          echo "Setting JWT: $JWT"
           sed -i "/arangodb.password/c\arangodb.jwt=$JWT" src/test/resources/arangodb.properties
       - name: Info
         run: mvn -version

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         docker-img:
           - docker.io/arangodb/arangodb:3.7.15
-          - docker.io/arangodb/arangodb:3.8.2
+          - docker.io/arangodb/arangodb:3.8.4
           - docker.io/arangodb/arangodb-preview:3.9.0-alpha.1
           - docker.io/arangodb/enterprise:3.7.15
-          - docker.io/arangodb/enterprise:3.8.2
+          - docker.io/arangodb/enterprise:3.8.4
           - docker.io/arangodb/enterprise-preview:3.9.0-alpha.1
         topology:
           - single
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: ${{matrix.java-version}}
@@ -56,6 +56,69 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
+      - name: Info
+        run: mvn -version
+      - name: Test
+        run: mvn --no-transfer-progress test -DargLine="-Duser.language=${{matrix.user-language}}"
+      - name: Collect docker logs on failure
+        if: ${{ cancelled() || failure() }}
+        uses: jwalton/gh-docker-logs@v1
+        with:
+          dest: './logs'
+      - name: Tar logs
+        if: ${{ cancelled() || failure() }}
+        run: tar cvzf ./logs.tgz ./logs
+      - name: Upload logs to GitHub
+        if: ${{ cancelled() || failure() }}
+        uses: actions/upload-artifact@master
+        with:
+          name: logs.tgz
+          path: ./logs.tgz
+
+  test-jwt:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-img:
+          - docker.io/arangodb/enterprise:3.8.4
+        topology:
+          - single
+          - cluster
+          - activefailover
+        db-ext-names:
+          - false
+        java-version:
+          - 17
+        user-language:
+          - en
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{matrix.java-version}}
+          distribution: 'adopt'
+      - name: Start Database
+        run: ./docker/start_db.sh
+        env:
+          ARANGO_LICENSE_KEY: ${{ secrets.ARANGO_LICENSE_KEY }}
+          STARTER_MODE: ${{matrix.topology}}
+          DOCKER_IMAGE: ${{matrix.docker-img}}
+          DATABASE_EXTENDED_NAMES: ${{matrix.db-ext-names}}
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: Set JWT
+        run: |
+          JWT=$(curl "http://172.17.0.1:8529/_db/_system/_open/auth" -X POST -d '{"username":"root","password":"test"}' | jq ".jwt" | xargs)
+          sed -i "/arangodb.password/c\arangodb.jwt=$JWT" src/test/resources/arangodb.properties
       - name: Info
         run: mvn -version
       - name: Test

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+- fixed swallowing connection exceptions (#420) 
+- fixed `stopwords` analyzer (#414)
+- set max retries for active failover redirects (#412)
+- fixed deserializing `null` value as String (#411)
+
 ## [6.14.0] - 2021-10-01
 
 - fixed issues with non-English locales (#407)

--- a/docker/find_active_endpoint.sh
+++ b/docker/find_active_endpoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+COORDINATORS=("172.17.0.1:8529" "172.17.0.1:8539" "172.17.0.1:8549")
+
+for a in ${COORDINATORS[*]} ; do
+    if curl -u root:test --silent --fail "http://$a"; then
+        echo "$a"
+        exit 0
+    fi
+done
+
+echo "Could not find any active endpoint!"
+exit 1

--- a/src/main/java/com/arangodb/ArangoDB.java
+++ b/src/main/java/com/arangodb/ArangoDB.java
@@ -652,7 +652,12 @@ public interface ArangoDB extends ArangoSerializationAccessor {
                     new VstCommunicationSync.Builder(hostHandler).timeout(timeout).user(user).password(password)
                             .useSsl(useSsl).sslContext(sslContext).chunksize(chunksize).maxConnections(maxConnections)
                             .connectionTtl(connectionTtl),
-                    new HttpCommunication.Builder(hostHandler), util, protocol, hostResolver, new ArangoContext());
+                    new HttpCommunication.Builder(hostHandler),
+                    util,
+                    protocol,
+                    hostResolver,
+                    hostHandler,
+                    new ArangoContext());
         }
 
     }
@@ -663,6 +668,14 @@ public interface ArangoDB extends ArangoSerializationAccessor {
      * @throws ArangoDBException
      */
     void shutdown() throws ArangoDBException;
+
+    /**
+     * Updates the bearer jwt used for requests authorization. This is only effective when using HTTP protocol. VST
+     * connections are only authenticated during the initialization.
+     *
+     * @param jwt the token to use
+     */
+    void updateJwt(String jwt);
 
     /**
      * Returns a {@code ArangoDatabase} instance for the {@code _system} database.
@@ -897,10 +910,8 @@ public interface ArangoDB extends ArangoSerializationAccessor {
     /**
      * Returns fatal, error, warning or info log messages from the server's global log.
      *
-     * @param options
-     *         Additional options, can be null
+     * @param options Additional options, can be null
      * @return the log messages
-     *
      * @throws ArangoDBException
      * @see <a href= "https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#read-global-logs-from-the-server">API
      * Documentation</a>
@@ -912,10 +923,8 @@ public interface ArangoDB extends ArangoSerializationAccessor {
     /**
      * Returns the server logs
      *
-     * @param options
-     *         Additional options, can be null
+     * @param options Additional options, can be null
      * @return the log messages
-     *
      * @see <a href= "https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#read-global-logs-from-the-server">API
      * Documentation</a>
      * @since ArangoDB 3.8

--- a/src/main/java/com/arangodb/ArangoDB.java
+++ b/src/main/java/com/arangodb/ArangoDB.java
@@ -180,7 +180,7 @@ public interface ArangoDB extends ArangoSerializationAccessor {
         }
 
         /**
-         * Sets the JWT for the user for authentication.
+         * Sets the JWT for the user authentication.
          *
          * @param jwt token to use (default: {@code null})
          * @return {@link ArangoDB.Builder}
@@ -682,8 +682,8 @@ public interface ArangoDB extends ArangoSerializationAccessor {
     void shutdown() throws ArangoDBException;
 
     /**
-     * Updates the JWT used for requests authorization. This is only effective when using HTTP protocol. VST
-     * connections are only authenticated during the initialization.
+     * Updates the JWT used for requests authorization. It does not change already existing VST connections, since VST
+     * connections are authenticated during the initialization phase.
      *
      * @param jwt token to use
      */

--- a/src/main/java/com/arangodb/ArangoDB.java
+++ b/src/main/java/com/arangodb/ArangoDB.java
@@ -180,6 +180,17 @@ public interface ArangoDB extends ArangoSerializationAccessor {
         }
 
         /**
+         * Sets the JWT for the user for authentication.
+         *
+         * @param jwt token to use (default: {@code null})
+         * @return {@link ArangoDB.Builder}
+         */
+        public Builder jwt(final String jwt) {
+            setJwt(jwt);
+            return this;
+        }
+
+        /**
          * If set to {@code true} SSL will be used when connecting to an ArangoDB server.
          *
          * @param useSsl whether or not use SSL (default: {@code false})
@@ -217,7 +228,7 @@ public interface ArangoDB extends ArangoSerializationAccessor {
          *
          * @param httpRequestRetryHandler HttpRequestRetryHandler to be used
          * @return {@link ArangoDB.Builder}
-         *
+         * <p>
          * <br /><br />
          * NOTE:
          * Some ArangoDB HTTP endpoints do not honor RFC-2616 HTTP 1.1 specification in respect to
@@ -647,11 +658,12 @@ public interface ArangoDB extends ArangoSerializationAccessor {
             final Collection<Host> hostList = createHostList(max, connectionFactory);
             final HostResolver hostResolver = createHostResolver(hostList, max, connectionFactory);
             final HostHandler hostHandler = createHostHandler(hostResolver);
+            hostHandler.setJwt(jwt);
 
             return new ArangoDBImpl(
                     new VstCommunicationSync.Builder(hostHandler).timeout(timeout).user(user).password(password)
-                            .useSsl(useSsl).sslContext(sslContext).chunksize(chunksize).maxConnections(maxConnections)
-                            .connectionTtl(connectionTtl),
+                            .jwt(jwt).useSsl(useSsl).sslContext(sslContext).chunksize(chunksize)
+                            .maxConnections(maxConnections).connectionTtl(connectionTtl),
                     new HttpCommunication.Builder(hostHandler),
                     util,
                     protocol,
@@ -670,10 +682,10 @@ public interface ArangoDB extends ArangoSerializationAccessor {
     void shutdown() throws ArangoDBException;
 
     /**
-     * Updates the bearer jwt used for requests authorization. This is only effective when using HTTP protocol. VST
+     * Updates the JWT used for requests authorization. This is only effective when using HTTP protocol. VST
      * connections are only authenticated during the initialization.
      *
-     * @param jwt the token to use
+     * @param jwt token to use
      */
     void updateJwt(String jwt);
 

--- a/src/main/java/com/arangodb/async/ArangoDBAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoDBAsync.java
@@ -75,6 +75,14 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
     void shutdown() throws ArangoDBException;
 
     /**
+     * Updates the JWT used for requests authorization. This is only effective when using HTTP protocol. VST
+     * connections are only authenticated during the initialization.
+     *
+     * @param jwt token to use
+     */
+    void updateJwt(String jwt);
+
+    /**
      * Returns a handler of the system database
      *
      * @return database handler
@@ -263,10 +271,8 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
     /**
      * Returns fatal, error, warning or info log messages from the server's global log.
      *
-     * @param options
-     *         Additional options, can be null
+     * @param options Additional options, can be null
      * @return the log messages
-     *
      * @see <a href= "https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#read-global-logs-from-the-server">API
      * Documentation</a>
      * @deprecated use {@link #getLogEntries(LogOptions)} instead
@@ -277,10 +283,8 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
     /**
      * Returns the server logs
      *
-     * @param options
-     *         Additional options, can be null
+     * @param options Additional options, can be null
      * @return the log messages
-     *
      * @see <a href= "https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#read-global-logs-from-the-server">API
      * Documentation</a>
      * @since ArangoDB 3.8
@@ -805,18 +809,20 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
                     syncBuilder(syncHostHandler),
                     asyncHostResolver,
                     syncHostResolver,
+                    asyncHostHandler,
+                    syncHostHandler,
                     new ArangoContext());
         }
 
         private VstCommunicationAsync.Builder asyncBuilder(final HostHandler hostHandler) {
             return new VstCommunicationAsync.Builder(hostHandler).timeout(timeout).user(user).password(password)
-                    .useSsl(useSsl).sslContext(sslContext).chunksize(chunksize).maxConnections(maxConnections)
+                    .jwt(jwt).useSsl(useSsl).sslContext(sslContext).chunksize(chunksize).maxConnections(maxConnections)
                     .connectionTtl(connectionTtl);
         }
 
         private VstCommunicationSync.Builder syncBuilder(final HostHandler hostHandler) {
             return new VstCommunicationSync.Builder(hostHandler).timeout(timeout).user(user).password(password)
-                    .useSsl(useSsl).sslContext(sslContext).chunksize(chunksize).maxConnections(maxConnections)
+                    .jwt(jwt).useSsl(useSsl).sslContext(sslContext).chunksize(chunksize).maxConnections(maxConnections)
                     .connectionTtl(connectionTtl);
         }
 

--- a/src/main/java/com/arangodb/async/ArangoDBAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoDBAsync.java
@@ -26,14 +26,7 @@ import com.arangodb.Protocol;
 import com.arangodb.async.internal.ArangoDBAsyncImpl;
 import com.arangodb.async.internal.velocystream.VstCommunicationAsync;
 import com.arangodb.async.internal.velocystream.VstConnectionFactoryAsync;
-import com.arangodb.entity.ArangoDBVersion;
-import com.arangodb.entity.LoadBalancingStrategy;
-import com.arangodb.entity.LogEntity;
-import com.arangodb.entity.LogEntriesEntity;
-import com.arangodb.entity.LogLevelEntity;
-import com.arangodb.entity.Permissions;
-import com.arangodb.entity.ServerRole;
-import com.arangodb.entity.UserEntity;
+import com.arangodb.entity.*;
 import com.arangodb.internal.ArangoContext;
 import com.arangodb.internal.ArangoDefaults;
 import com.arangodb.internal.InternalArangoDBBuilder;
@@ -53,18 +46,7 @@ import com.arangodb.model.UserUpdateOptions;
 import com.arangodb.util.ArangoDeserializer;
 import com.arangodb.util.ArangoSerialization;
 import com.arangodb.util.ArangoSerializer;
-import com.arangodb.velocypack.VPack;
-import com.arangodb.velocypack.VPackAnnotationFieldFilter;
-import com.arangodb.velocypack.VPackAnnotationFieldNaming;
-import com.arangodb.velocypack.VPackDeserializer;
-import com.arangodb.velocypack.VPackInstanceCreator;
-import com.arangodb.velocypack.VPackJsonDeserializer;
-import com.arangodb.velocypack.VPackJsonSerializer;
-import com.arangodb.velocypack.VPackModule;
-import com.arangodb.velocypack.VPackParser;
-import com.arangodb.velocypack.VPackParserModule;
-import com.arangodb.velocypack.VPackSerializer;
-import com.arangodb.velocypack.ValueType;
+import com.arangodb.velocypack.*;
 import com.arangodb.velocystream.Request;
 import com.arangodb.velocystream.Response;
 
@@ -380,6 +362,17 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
          */
         public Builder password(final String password) {
             setPassword(password);
+            return this;
+        }
+
+        /**
+         * Sets the JWT for the user for authentication.
+         *
+         * @param jwt token to use (default: {@code null})
+         * @return {@link ArangoDBAsync.Builder}
+         */
+        public Builder jwt(final String jwt) {
+            setJwt(jwt);
             return this;
         }
 

--- a/src/main/java/com/arangodb/async/ArangoDBAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoDBAsync.java
@@ -75,8 +75,8 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
     void shutdown() throws ArangoDBException;
 
     /**
-     * Updates the JWT used for requests authorization. This is only effective when using HTTP protocol. VST
-     * connections are only authenticated during the initialization.
+     * Updates the JWT used for requests authorization. It does not change already existing VST connections, since VST
+     * connections are authenticated during the initialization phase.
      *
      * @param jwt token to use
      */
@@ -370,7 +370,7 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
         }
 
         /**
-         * Sets the JWT for the user for authentication.
+         * Sets the JWT for the user authentication.
          *
          * @param jwt token to use (default: {@code null})
          * @return {@link ArangoDBAsync.Builder}

--- a/src/main/java/com/arangodb/async/internal/ArangoExecutorAsync.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoExecutorAsync.java
@@ -80,4 +80,9 @@ public class ArangoExecutorAsync extends ArangoExecutor {
             outgoingExecutor.shutdown();
         }
     }
+
+    public void setJwt(String jwt) {
+        communication.setJwt(jwt);
+    }
+
 }

--- a/src/main/java/com/arangodb/async/internal/velocystream/VstCommunicationAsync.java
+++ b/src/main/java/com/arangodb/async/internal/velocystream/VstCommunicationAsync.java
@@ -49,9 +49,9 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
     private static final Logger LOGGER = LoggerFactory.getLogger(VstCommunicationAsync.class);
 
     private VstCommunicationAsync(final HostHandler hostHandler, final Integer timeout, final String user,
-                                  final String password, final Boolean useSsl, final SSLContext sslContext, final ArangoSerialization util,
+                                  final String password, final String jwt, final Boolean useSsl, final SSLContext sslContext, final ArangoSerialization util,
                                   final Integer chunksize, final Integer maxConnections, final Long connectionTtl) {
-        super(timeout, user, password, useSsl, sslContext, util, chunksize, hostHandler);
+        super(timeout, user, password, jwt, useSsl, sslContext, util, chunksize, hostHandler);
     }
 
     @Override
@@ -125,6 +125,7 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
 
     @Override
     protected void authenticate(final VstConnectionAsync connection) {
+        // TODO: jwt authentication request
         Response response;
         try {
             response = execute(new AuthenticationRequest(user, password != null ? password : "", ENCRYPTION_PLAIN),
@@ -142,6 +143,7 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
         private Long connectionTtl;
         private String user;
         private String password;
+        private String jwt;
         private Boolean useSsl;
         private SSLContext sslContext;
         private Integer chunksize;
@@ -164,6 +166,11 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
 
         public Builder password(final String password) {
             this.password = password;
+            return this;
+        }
+
+        public Builder jwt(final String jwt) {
+            this.jwt = jwt;
             return this;
         }
 
@@ -193,7 +200,7 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
         }
 
         public VstCommunicationAsync build(final ArangoSerialization util) {
-            return new VstCommunicationAsync(hostHandler, timeout, user, password, useSsl, sslContext, util, chunksize,
+            return new VstCommunicationAsync(hostHandler, timeout, user, password, jwt, useSsl, sslContext, util, chunksize,
                     maxConnections, connectionTtl);
         }
     }

--- a/src/main/java/com/arangodb/internal/ArangoDBImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoDBImpl.java
@@ -129,6 +129,8 @@ public class ArangoDBImpl extends InternalArangoDB<ArangoExecutorSync> implement
     @Override
     public void updateJwt(String jwt) {
         hostHandler.setJwt(jwt);
+        cp.setJwt(jwt);
+        executor.setJwt(jwt);
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/ArangoDBImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoDBImpl.java
@@ -29,6 +29,7 @@ import com.arangodb.internal.http.HttpCommunication;
 import com.arangodb.internal.http.HttpProtocol;
 import com.arangodb.internal.net.CommunicationProtocol;
 import com.arangodb.internal.net.HostHandle;
+import com.arangodb.internal.net.HostHandler;
 import com.arangodb.internal.net.HostResolver;
 import com.arangodb.internal.util.ArangoSerializationFactory;
 import com.arangodb.internal.util.ArangoSerializationFactory.Serializer;
@@ -59,10 +60,11 @@ public class ArangoDBImpl extends InternalArangoDB<ArangoExecutorSync> implement
 
     private ArangoCursorInitializer cursorInitializer;
     private final CommunicationProtocol cp;
+    private final HostHandler hostHandler;
 
     public ArangoDBImpl(final VstCommunicationSync.Builder vstBuilder, final HttpCommunication.Builder httpBuilder,
                         final ArangoSerializationFactory util, final Protocol protocol, final HostResolver hostResolver,
-                        final ArangoContext context) {
+                        final HostHandler hostHandler, final ArangoContext context) {
 
         super(new ArangoExecutorSync(
                         createProtocol(vstBuilder, httpBuilder, util.get(Serializer.INTERNAL), protocol),
@@ -76,6 +78,7 @@ public class ArangoDBImpl extends InternalArangoDB<ArangoExecutorSync> implement
                 new HttpCommunication.Builder(httpBuilder),
                 util.get(Serializer.INTERNAL),
                 protocol);
+        this.hostHandler = hostHandler;
 
         hostResolver.init(this.executor(), util());
 
@@ -121,6 +124,11 @@ public class ArangoDBImpl extends InternalArangoDB<ArangoExecutorSync> implement
                 LOGGER.error("Got exception during shutdown:", e);
             }
         }
+    }
+
+    @Override
+    public void updateJwt(String jwt) {
+        hostHandler.setJwt(jwt);
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/ArangoExecutorSync.java
+++ b/src/main/java/com/arangodb/internal/ArangoExecutorSync.java
@@ -90,4 +90,9 @@ public class ArangoExecutorSync extends ArangoExecutor {
             throw new ArangoDBException(e);
         }
     }
+
+    public void setJwt(String jwt) {
+        protocol.setJwt(jwt);
+    }
+
 }

--- a/src/main/java/com/arangodb/internal/InternalArangoDBBuilder.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoDBBuilder.java
@@ -66,6 +66,7 @@ public abstract class InternalArangoDBBuilder {
     private static final String PROPERTY_KEY_TIMEOUT = "arangodb.timeout";
     private static final String PROPERTY_KEY_USER = "arangodb.user";
     private static final String PROPERTY_KEY_PASSWORD = "arangodb.password";
+    private static final String PROPERTY_KEY_JWT = "arangodb.jwt";
     private static final String PROPERTY_KEY_USE_SSL = "arangodb.usessl";
     private static final String PROPERTY_KEY_COOKIE_SPEC = "arangodb.httpCookieSpec";
     private static final String PROPERTY_KEY_V_STREAM_CHUNK_CONTENT_SIZE = "arangodb.chunksize";
@@ -82,6 +83,7 @@ public abstract class InternalArangoDBBuilder {
     protected Integer timeout;
     protected String user;
     protected String password;
+    protected String jwt;
     protected Boolean useSsl;
     protected String httpCookieSpec;
     protected HttpRequestRetryHandler httpRequestRetryHandler;
@@ -140,6 +142,7 @@ public abstract class InternalArangoDBBuilder {
         timeout = loadTimeout(properties, timeout);
         user = loadUser(properties, user);
         password = loadPassword(properties, password);
+        jwt = loadJwt(properties, jwt);
         useSsl = loadUseSsl(properties, useSsl);
         httpCookieSpec = loadhttpCookieSpec(properties, httpCookieSpec);
         chunksize = loadChunkSize(properties, chunksize);
@@ -165,6 +168,10 @@ public abstract class InternalArangoDBBuilder {
 
     protected void setPassword(final String password) {
         this.password = password;
+    }
+
+    protected void setJwt(final String jwt) {
+        this.jwt = jwt;
     }
 
     protected void setUseSsl(final Boolean useSsl) {
@@ -303,6 +310,10 @@ public abstract class InternalArangoDBBuilder {
 
     private static String loadPassword(final Properties properties, final String currentValue) {
         return getProperty(properties, PROPERTY_KEY_PASSWORD, currentValue, null);
+    }
+
+    private static String loadJwt(final Properties properties, final String currentValue) {
+        return getProperty(properties, PROPERTY_KEY_JWT, currentValue, null);
     }
 
     private static Boolean loadUseSsl(final Properties properties, final Boolean currentValue) {

--- a/src/main/java/com/arangodb/internal/http/CURLLogger.java
+++ b/src/main/java/com/arangodb/internal/http/CURLLogger.java
@@ -42,7 +42,8 @@ public final class CURLLogger {
     public static void log(
             final String url,
             final Request request,
-            final Credentials credencials,
+            final Credentials credentials,
+            final String jwt,
             final ArangoSerialization util) {
         final RequestType requestType = request.getRequestType();
         final boolean includeBody = (requestType == RequestType.POST || requestType == RequestType.PUT
@@ -59,9 +60,12 @@ public final class CURLLogger {
                 buffer.append(" -H '").append(header.getKey()).append(":").append(header.getValue()).append("'");
             }
         }
-        if (credencials != null) {
-            buffer.append(" -u ").append(credencials.getUserPrincipal().getName()).append(":")
-                    .append(credencials.getPassword());
+        if (credentials != null) {
+            buffer.append(" -u ").append(credentials.getUserPrincipal().getName()).append(":")
+                    .append(credentials.getPassword());
+        }
+        if (jwt != null) {
+            buffer.append(" -H ").append("'Authorization: Bearer ").append(jwt).append("'");
         }
         if (includeBody) {
             buffer.append(" -d @-");

--- a/src/main/java/com/arangodb/internal/http/HttpConnection.java
+++ b/src/main/java/com/arangodb/internal/http/HttpConnection.java
@@ -318,10 +318,11 @@ public class HttpConnection implements Connection {
             httpRequest.setHeader("Accept", "application/x-velocypack");
         }
         addHeader(request, httpRequest);
+        Credentials credentials = null;
         if (jwt != null) {
             httpRequest.addHeader(AUTHORIZATION, "Bearer " + jwt);
         } else if (user != null) {
-            Credentials credentials = new UsernamePasswordCredentials(user, password != null ? password : "");
+            credentials = new UsernamePasswordCredentials(user, password != null ? password : "");
             try {
                 httpRequest.addHeader(new BasicScheme().authenticate(credentials, httpRequest, null));
             } catch (final AuthenticationException e) {
@@ -329,8 +330,7 @@ public class HttpConnection implements Connection {
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            // FIXME: add overloaded method to accept bearer token in addition to username and password
-            CURLLogger.log(url, request, null, util);
+            CURLLogger.log(url, request, credentials, jwt, util);
         }
         Response response;
         response = buildResponse(client.execute(httpRequest));

--- a/src/main/java/com/arangodb/internal/http/HttpConnection.java
+++ b/src/main/java/com/arangodb/internal/http/HttpConnection.java
@@ -69,6 +69,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+
 /**
  * @author Mark Vollmary
  */
@@ -163,6 +165,7 @@ public class HttpConnection implements Connection {
     private final CloseableHttpClient client;
     private final String user;
     private final String password;
+    private volatile String jwt = null;
     private final ArangoSerialization util;
     private final Boolean useSsl;
     private final Protocol contentType;
@@ -315,9 +318,19 @@ public class HttpConnection implements Connection {
             httpRequest.setHeader("Accept", "application/x-velocypack");
         }
         addHeader(request, httpRequest);
-        final Credentials credentials = addCredentials(httpRequest);
+        if (jwt != null) {
+            httpRequest.addHeader(AUTHORIZATION, "Bearer " + jwt);
+        } else if (user != null) {
+            Credentials credentials = new UsernamePasswordCredentials(user, password != null ? password : "");
+            try {
+                httpRequest.addHeader(new BasicScheme().authenticate(credentials, httpRequest, null));
+            } catch (final AuthenticationException e) {
+                throw new ArangoDBException(e);
+            }
+        }
         if (LOGGER.isDebugEnabled()) {
-            CURLLogger.log(url, request, credentials, util);
+            // FIXME: add overloaded method to accept bearer token in addition to username and password
+            CURLLogger.log(url, request, null, util);
         }
         Response response;
         response = buildResponse(client.execute(httpRequest));
@@ -329,19 +342,6 @@ public class HttpConnection implements Connection {
         for (final Entry<String, String> header : request.getHeaderParam().entrySet()) {
             httpRequest.addHeader(header.getKey(), header.getValue());
         }
-    }
-
-    public Credentials addCredentials(final HttpRequestBase httpRequest) {
-        Credentials credentials = null;
-        if (user != null) {
-            credentials = new UsernamePasswordCredentials(user, password != null ? password : "");
-            try {
-                httpRequest.addHeader(new BasicScheme().authenticate(credentials, httpRequest, null));
-            } catch (final AuthenticationException e) {
-                throw new ArangoDBException(e);
-            }
-        }
-        return credentials;
     }
 
     public Response buildResponse(final CloseableHttpResponse httpResponse)
@@ -373,6 +373,11 @@ public class HttpConnection implements Connection {
 
     protected void checkError(final Response response) throws ArangoDBException {
         ResponseUtils.checkError(util, response);
+    }
+
+    @Override
+    public void setJwt(String jwt) {
+        this.jwt = jwt;
     }
 
 }

--- a/src/main/java/com/arangodb/internal/http/HttpProtocol.java
+++ b/src/main/java/com/arangodb/internal/http/HttpProtocol.java
@@ -46,6 +46,11 @@ public class HttpProtocol implements CommunicationProtocol {
     }
 
     @Override
+    public void setJwt(String jwt) {
+        // no-op: jwt is updated in the host handlers
+    }
+
+    @Override
     public void close() throws IOException {
         httpCommunitaction.close();
     }

--- a/src/main/java/com/arangodb/internal/net/CommunicationProtocol.java
+++ b/src/main/java/com/arangodb/internal/net/CommunicationProtocol.java
@@ -33,4 +33,6 @@ public interface CommunicationProtocol extends Closeable {
 
     Response execute(final Request request, HostHandle hostHandle) throws ArangoDBException;
 
+    void setJwt(String jwt);
+
 }

--- a/src/main/java/com/arangodb/internal/net/Connection.java
+++ b/src/main/java/com/arangodb/internal/net/Connection.java
@@ -26,5 +26,5 @@ import java.io.Closeable;
  * @author Mark Vollmary
  */
 public interface Connection extends Closeable {
-
+    void setJwt(String jwt);
 }

--- a/src/main/java/com/arangodb/internal/net/ConnectionPool.java
+++ b/src/main/java/com/arangodb/internal/net/ConnectionPool.java
@@ -31,4 +31,6 @@ public interface ConnectionPool extends Closeable {
 
     Connection connection();
 
+    void setJwt(String jwt);
+
 }

--- a/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
+++ b/src/main/java/com/arangodb/internal/net/ConnectionPoolImpl.java
@@ -41,6 +41,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
     private final List<Connection> connections;
     private int current;
     private final ConnectionFactory factory;
+    private volatile String jwt = null;
 
     public ConnectionPoolImpl(final HostDescription host, final Integer maxConnections,
                               final ConnectionFactory factory) {
@@ -54,7 +55,9 @@ public class ConnectionPoolImpl implements ConnectionPool {
 
     @Override
     public Connection createConnection(final HostDescription host) {
-        return factory.create(host);
+        Connection c = factory.create(host);
+        c.setJwt(jwt);
+        return c;
     }
 
     @Override
@@ -76,6 +79,14 @@ public class ConnectionPoolImpl implements ConnectionPool {
         }
 
         return connection;
+    }
+
+    @Override
+    public void setJwt(String jwt) {
+        this.jwt = jwt;
+        for (Connection connection : connections) {
+            connection.setJwt(jwt);
+        }
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/net/DirtyReadHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/DirtyReadHostHandler.java
@@ -81,4 +81,10 @@ public class DirtyReadHostHandler implements HostHandler {
         determineHostHandler().closeCurrentOnError();
     }
 
+    @Override
+    public void setJwt(String jwt) {
+        master.setJwt(jwt);
+        follower.setJwt(jwt);
+    }
+
 }

--- a/src/main/java/com/arangodb/internal/net/FallbackHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/FallbackHostHandler.java
@@ -104,4 +104,9 @@ public class FallbackHostHandler implements HostHandler {
         current.closeOnError();
     }
 
+    @Override
+    public void setJwt(String jwt) {
+        hosts.setJwt(jwt);
+    }
+
 }

--- a/src/main/java/com/arangodb/internal/net/Host.java
+++ b/src/main/java/com/arangodb/internal/net/Host.java
@@ -38,4 +38,7 @@ public interface Host {
     void setMarkforDeletion(boolean markforDeletion);
 
     boolean isMarkforDeletion();
+
+    void setJwt(String jwt);
+
 }

--- a/src/main/java/com/arangodb/internal/net/HostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/HostHandler.java
@@ -40,4 +40,7 @@ public interface HostHandler {
     void close() throws IOException;
 
     void closeCurrentOnError();
+
+    void setJwt(String jwt);
+
 }

--- a/src/main/java/com/arangodb/internal/net/HostImpl.java
+++ b/src/main/java/com/arangodb/internal/net/HostImpl.java
@@ -73,6 +73,11 @@ public class HostImpl implements Host {
         return markforDeletion;
     }
 
+    @Override
+    public void setJwt(String jwt) {
+        connectionPool.setJwt(jwt);
+    }
+
     public void setMarkforDeletion(boolean markforDeletion) {
         this.markforDeletion = markforDeletion;
     }

--- a/src/main/java/com/arangodb/internal/net/HostSet.java
+++ b/src/main/java/com/arangodb/internal/net/HostSet.java
@@ -13,6 +13,7 @@ public class HostSet {
     private static final Logger LOGGER = LoggerFactory.getLogger(HostSet.class);
 
     private final ArrayList<Host> hosts = new ArrayList<>();
+    private volatile String jwt = null;
 
     public HostSet() {
         super();
@@ -32,21 +33,18 @@ public class HostSet {
     }
 
     public void addHost(Host newHost) {
-
         if (hosts.contains(newHost)) {
             LOGGER.debug("Host" + newHost + " already in Set");
-
             for (Host host : hosts) {
                 if (host.equals(newHost)) {
                     host.setMarkforDeletion(false);
                 }
             }
-
         } else {
+            newHost.setJwt(jwt);
             hosts.add(newHost);
             LOGGER.debug("Added Host " + newHost + " - now " + hosts.size() + " Hosts in List");
         }
-
     }
 
     public void close() {
@@ -101,6 +99,7 @@ public class HostSet {
     }
 
     public void setJwt(String jwt) {
+        this.jwt = jwt;
         for (Host h : hosts) {
             h.setJwt(jwt);
         }

--- a/src/main/java/com/arangodb/internal/net/HostSet.java
+++ b/src/main/java/com/arangodb/internal/net/HostSet.java
@@ -77,7 +77,7 @@ public class HostSet {
         LOGGER.debug("Clear all Hosts in Set with markForDeletion");
 
         Iterator<Host> iterable = hosts.iterator();
-        while (iterable.hasNext()){
+        while (iterable.hasNext()) {
             Host host = iterable.next();
             if (host.isMarkforDeletion()) {
                 try {
@@ -99,4 +99,11 @@ public class HostSet {
         close();
         hosts.clear();
     }
+
+    public void setJwt(String jwt) {
+        for (Host h : hosts) {
+            h.setJwt(jwt);
+        }
+    }
+
 }

--- a/src/main/java/com/arangodb/internal/net/RandomHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RandomHostHandler.java
@@ -85,4 +85,10 @@ public class RandomHostHandler implements HostHandler {
         current.closeOnError();
     }
 
+    @Override
+    public void setJwt(String jwt) {
+        fallback.setJwt(jwt);
+        hosts.setJwt(jwt);
+    }
+
 }

--- a/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
@@ -109,4 +109,9 @@ public class RoundRobinHostHandler implements HostHandler {
         currentHost.closeOnError();
     }
 
+    @Override
+    public void setJwt(String jwt) {
+        hosts.setJwt(jwt);
+    }
+
 }

--- a/src/main/java/com/arangodb/internal/velocypack/VPackDriverModule.java
+++ b/src/main/java/com/arangodb/internal/velocypack/VPackDriverModule.java
@@ -27,6 +27,7 @@ import com.arangodb.entity.arangosearch.ConsolidationPolicy;
 import com.arangodb.entity.arangosearch.ConsolidationType;
 import com.arangodb.entity.arangosearch.analyzer.SearchAnalyzer;
 import com.arangodb.internal.velocystream.internal.AuthenticationRequest;
+import com.arangodb.internal.velocystream.internal.JwtAuthenticationRequest;
 import com.arangodb.model.CollectionSchema;
 import com.arangodb.model.TraversalOptions;
 import com.arangodb.model.arangosearch.ArangoSearchPropertiesOptions;
@@ -55,6 +56,7 @@ public class VPackDriverModule implements VPackModule, VPackParserModule {
         });
         context.registerSerializer(Request.class, VPackSerializers.REQUEST);
         context.registerSerializer(AuthenticationRequest.class, VPackSerializers.AUTH_REQUEST);
+        context.registerSerializer(JwtAuthenticationRequest.class, VPackSerializers.JWT_AUTH_REQUEST);
         context.registerSerializer(CollectionType.class, VPackSerializers.COLLECTION_TYPE);
         context.registerSerializer(BaseDocument.class, VPackSerializers.BASE_DOCUMENT);
         context.registerSerializer(BaseEdgeDocument.class, VPackSerializers.BASE_EDGE_DOCUMENT);

--- a/src/main/java/com/arangodb/internal/velocypack/VPackSerializers.java
+++ b/src/main/java/com/arangodb/internal/velocypack/VPackSerializers.java
@@ -38,6 +38,7 @@ import com.arangodb.entity.arangosearch.PrimarySort;
 import com.arangodb.entity.arangosearch.StoreValuesType;
 import com.arangodb.entity.arangosearch.StoredValue;
 import com.arangodb.internal.velocystream.internal.AuthenticationRequest;
+import com.arangodb.internal.velocystream.internal.JwtAuthenticationRequest;
 import com.arangodb.model.CollectionSchema;
 import com.arangodb.model.TraversalOptions;
 import com.arangodb.model.TraversalOptions.Order;
@@ -87,6 +88,15 @@ public class VPackSerializers {
         builder.add(value.getEncryption());
         builder.add(value.getUser());
         builder.add(value.getPassword());
+        builder.close();
+    };
+
+    public static final VPackSerializer<JwtAuthenticationRequest> JWT_AUTH_REQUEST = (builder, attribute, value, context) -> {
+        builder.add(attribute, ValueType.ARRAY);
+        builder.add(value.getVersion());
+        builder.add(value.getType());
+        builder.add(value.getEncryption());
+        builder.add(value.getToken());
         builder.close();
     };
 

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
@@ -59,15 +59,17 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
 
     protected final String user;
     protected final String password;
+    protected final String jwt;
 
     protected final Integer chunksize;
     protected final HostHandler hostHandler;
 
-    protected VstCommunication(final Integer timeout, final String user, final String password, final Boolean useSsl,
-                               final SSLContext sslContext, final ArangoSerialization util, final Integer chunksize,
-                               final HostHandler hostHandler) {
+    protected VstCommunication(final Integer timeout, final String user, final String password, final String jwt,
+                               final Boolean useSsl, final SSLContext sslContext, final ArangoSerialization util,
+                               final Integer chunksize, final HostHandler hostHandler) {
         this.user = user;
         this.password = password;
+        this.jwt = jwt;
         this.util = util;
         this.hostHandler = hostHandler;
         this.chunksize = chunksize != null ? chunksize : ArangoDefaults.CHUNK_DEFAULT_CONTENT_SIZE;

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunication.java
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public abstract class VstCommunication<R, C extends VstConnection> implements Closeable {
 
     protected static final String ENCRYPTION_PLAIN = "plain";
+    protected static final String ENCRYPTION_JWT = "jwt";
     private static final Logger LOGGER = LoggerFactory.getLogger(VstCommunication.class);
 
     protected static final AtomicLong mId = new AtomicLong(0L);
@@ -59,7 +60,7 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
 
     protected final String user;
     protected final String password;
-    protected final String jwt;
+    protected volatile String jwt;
 
     protected final Integer chunksize;
     protected final HostHandler hostHandler;
@@ -91,7 +92,7 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
                 try {
                     connection.open();
                     hostHandler.success();
-                    if (user != null) {
+                    if (jwt != null || user != null) {
                         tryAuthenticate(connection);
                     }
                     hostHandler.confirm();
@@ -192,5 +193,10 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
         }
         return chunks;
     }
+
+    public void setJwt(String jwt) {
+        this.jwt = jwt;
+    }
+
 
 }

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
@@ -52,6 +52,7 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
         private Long connectionTtl;
         private String user;
         private String password;
+        private String jwt;
         private Boolean useSsl;
         private SSLContext sslContext;
         private Integer chunksize;
@@ -64,8 +65,9 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
 
         public Builder(final Builder builder) {
             this(builder.hostHandler);
-            timeout(builder.timeout).user(builder.user).password(builder.password).useSsl(builder.useSsl)
-                    .sslContext(builder.sslContext).chunksize(builder.chunksize).maxConnections(builder.maxConnections);
+            timeout(builder.timeout).user(builder.user).password(builder.password).jwt(builder.jwt)
+                    .useSsl(builder.useSsl).sslContext(builder.sslContext).chunksize(builder.chunksize)
+                    .maxConnections(builder.maxConnections);
         }
 
         public Builder timeout(final Integer timeout) {
@@ -80,6 +82,11 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
 
         public Builder password(final String password) {
             this.password = password;
+            return this;
+        }
+
+        public Builder jwt(final String jwt) {
+            this.jwt = jwt;
             return this;
         }
 
@@ -109,16 +116,17 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
         }
 
         public VstCommunication<Response, VstConnectionSync> build(final ArangoSerialization util) {
-            return new VstCommunicationSync(hostHandler, timeout, user, password, useSsl, sslContext, util, chunksize,
+            return new VstCommunicationSync(hostHandler, timeout, user, password, jwt, useSsl, sslContext, util, chunksize,
                     maxConnections, connectionTtl);
         }
 
     }
 
     protected VstCommunicationSync(final HostHandler hostHandler, final Integer timeout, final String user,
-                                   final String password, final Boolean useSsl, final SSLContext sslContext, final ArangoSerialization util,
+                                   final String password, final String jwt, final Boolean useSsl,
+                                   final SSLContext sslContext, final ArangoSerialization util,
                                    final Integer chunksize, final Integer maxConnections, final Long ttl) {
-        super(timeout, user, password, useSsl, sslContext, util, chunksize, hostHandler);
+        super(timeout, user, password, jwt, useSsl, sslContext, util, chunksize, hostHandler);
     }
 
     @Override
@@ -158,6 +166,7 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
 
     @Override
     protected void authenticate(final VstConnectionSync connection) {
+        // TODO: jwt authentication request
         final Response response = execute(
                 new AuthenticationRequest(user, password != null ? password : "", ENCRYPTION_PLAIN), connection);
         checkError(response);

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
@@ -27,6 +27,7 @@ import com.arangodb.internal.net.HostHandle;
 import com.arangodb.internal.net.HostHandler;
 import com.arangodb.internal.util.HostUtils;
 import com.arangodb.internal.velocystream.internal.AuthenticationRequest;
+import com.arangodb.internal.velocystream.internal.JwtAuthenticationRequest;
 import com.arangodb.internal.velocystream.internal.Message;
 import com.arangodb.internal.velocystream.internal.VstConnectionSync;
 import com.arangodb.util.ArangoSerialization;
@@ -166,9 +167,13 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
 
     @Override
     protected void authenticate(final VstConnectionSync connection) {
-        // TODO: jwt authentication request
-        final Response response = execute(
-                new AuthenticationRequest(user, password != null ? password : "", ENCRYPTION_PLAIN), connection);
+        Request authRequest;
+        if (jwt != null) {
+            authRequest = new JwtAuthenticationRequest(jwt, ENCRYPTION_JWT);
+        } else {
+            authRequest = new AuthenticationRequest(user, password != null ? password : "", ENCRYPTION_PLAIN);
+        }
+        final Response response = execute(authRequest, connection);
         checkError(response);
     }
 

--- a/src/main/java/com/arangodb/internal/velocystream/VstProtocol.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstProtocol.java
@@ -47,6 +47,11 @@ public class VstProtocol implements CommunicationProtocol {
     }
 
     @Override
+    public void setJwt(String jwt) {
+        communication.setJwt(jwt);
+    }
+
+    @Override
     public void close() throws IOException {
         communication.close();
     }

--- a/src/main/java/com/arangodb/internal/velocystream/internal/JwtAuthenticationRequest.java
+++ b/src/main/java/com/arangodb/internal/velocystream/internal/JwtAuthenticationRequest.java
@@ -1,0 +1,25 @@
+package com.arangodb.internal.velocystream.internal;
+
+import com.arangodb.velocystream.Request;
+
+public class JwtAuthenticationRequest extends Request {
+
+    private final String token;
+    private final String encryption;    // "jwt"
+
+    public JwtAuthenticationRequest(final String token, final String encryption) {
+        super(null, null, null);
+        this.token = token;
+        this.encryption = encryption;
+        setType(1000);
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getEncryption() {
+        return encryption;
+    }
+
+}

--- a/src/main/java/com/arangodb/internal/velocystream/internal/VstConnection.java
+++ b/src/main/java/com/arangodb/internal/velocystream/internal/VstConnection.java
@@ -356,4 +356,8 @@ public abstract class VstConnection<T> implements Connection {
         return this.connectionName;
     }
 
+    @Override
+    public void setJwt(String jwt) {
+        // no-op: VST connections send jwt token only at initialization time
+    }
 }

--- a/src/test/java/com/arangodb/ArangoDBTest.java
+++ b/src/test/java/com/arangodb/ArangoDBTest.java
@@ -388,7 +388,7 @@ public class ArangoDBTest {
 
     @Test
     public void authenticationFailPassword() {
-        final ArangoDB arangoDB = new ArangoDB.Builder().password("no").build();
+        final ArangoDB arangoDB = new ArangoDB.Builder().password("no").jwt(null).build();
         try {
             arangoDB.getVersion();
             fail();
@@ -399,7 +399,7 @@ public class ArangoDBTest {
 
     @Test
     public void authenticationFailUser() {
-        final ArangoDB arangoDB = new ArangoDB.Builder().user("no").build();
+        final ArangoDB arangoDB = new ArangoDB.Builder().user("no").jwt(null).build();
         try {
             arangoDB.getVersion();
             fail();

--- a/src/test/java/com/arangodb/JwtAuthTest.java
+++ b/src/test/java/com/arangodb/JwtAuthTest.java
@@ -1,0 +1,120 @@
+package com.arangodb;
+
+import com.arangodb.util.ArangoSerialization;
+import com.arangodb.velocystream.Request;
+import com.arangodb.velocystream.RequestType;
+import com.arangodb.velocystream.Response;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Michele Rastelli
+ */
+@RunWith(Parameterized.class)
+public class JwtAuthTest {
+
+    private static String jwt;
+    private final Protocol protocol;
+
+    @BeforeClass
+    public static void init() {
+        ArangoDB arangoDB = new ArangoDB.Builder().build();
+        jwt = getJwt(arangoDB);
+        arangoDB.shutdown();
+    }
+
+    @Parameterized.Parameters
+    public static List<Protocol> builders() {
+        return Arrays.asList(
+                Protocol.VST,
+                Protocol.HTTP_JSON,
+                Protocol.HTTP_VPACK
+        );
+    }
+
+    public JwtAuthTest(Protocol protocol) {
+        this.protocol = protocol;
+    }
+
+    @Test
+    public void notAuthenticated() {
+        ArangoDB arangoDB = getBuilder().build();
+        try {
+            arangoDB.getVersion();
+            fail();
+        } catch (ArangoDBException e) {
+            assertThat(e.getResponseCode(), is(401));
+        } finally {
+            arangoDB.shutdown();
+        }
+    }
+
+    @Test
+    public void jwtAndUsernameShouldThrow() {
+        try {
+            getBuilder()
+                    .user("foo")
+                    //                .jwt(jwt)
+                    .build();
+            fail();
+        } catch (ArangoDBException e) {
+            assertThat(e.getMessage(), containsString("Cannot use user name together with JWT."));
+        }
+    }
+
+    @Test
+    public void jwtAndPasswordShouldThrow() {
+        try {
+            getBuilder()
+                    .password("foo")
+                    //                .jwt(jwt)
+                    .build();
+            fail();
+        } catch (ArangoDBException e) {
+            assertThat(e.getMessage(), containsString("Cannot use password together with JWT."));
+        }
+    }
+
+    @Test
+    public void authenticated() {
+        System.out.println(jwt);
+        ArangoDB arangoDB = getBuilder()
+//                .jwt(jwt)
+                .build();
+        arangoDB.getVersion();
+        arangoDB.shutdown();
+    }
+
+    private ArangoDB.Builder getBuilder() {
+        return new ArangoDB.Builder()
+                .useProtocol(protocol)
+                .user(null)         // unset credentials from properties file
+                .password(null);    // unset credentials from properties file
+    }
+
+    private static String getJwt(ArangoDB arangoDB) {
+        ArangoSerialization serde = arangoDB.util();
+        Map<String, String> reqBody = new HashMap<>();
+        reqBody.put("username", "root");
+        reqBody.put("password", "test");
+
+        Request req = new Request("_system", RequestType.POST, "/_open/auth");
+        req.setBody(serde.serialize(reqBody));
+
+        Response resp = arangoDB.execute(req);
+        Map<String, String> respBody = serde.deserialize(resp.getBody(), Map.class);
+        return respBody.get("jwt");
+    }
+}

--- a/src/test/java/com/arangodb/JwtAuthTest.java
+++ b/src/test/java/com/arangodb/JwtAuthTest.java
@@ -14,10 +14,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Michele Rastelli
@@ -62,38 +62,34 @@ public class JwtAuthTest {
     }
 
     @Test
-    public void jwtAndUsernameShouldThrow() {
-        try {
-            getBuilder()
-                    .user("foo")
-                    //                .jwt(jwt)
-                    .build();
-            fail();
-        } catch (ArangoDBException e) {
-            assertThat(e.getMessage(), containsString("Cannot use user name together with JWT."));
-        }
-    }
-
-    @Test
-    public void jwtAndPasswordShouldThrow() {
-        try {
-            getBuilder()
-                    .password("foo")
-                    //                .jwt(jwt)
-                    .build();
-            fail();
-        } catch (ArangoDBException e) {
-            assertThat(e.getMessage(), containsString("Cannot use password together with JWT."));
-        }
-    }
-
-    @Test
     public void authenticated() {
         System.out.println(jwt);
         ArangoDB arangoDB = getBuilder()
 //                .jwt(jwt)
                 .build();
         arangoDB.getVersion();
+        arangoDB.shutdown();
+    }
+
+    @Test
+    public void updateJwt() {
+        assumeTrue("VST does not allow updating JWT", protocol != Protocol.VST);
+        System.out.println(jwt);
+        ArangoDB arangoDB = getBuilder()
+//                .jwt(jwt)
+                .build();
+        arangoDB.updateJwt(jwt);
+        arangoDB.getVersion();
+        arangoDB.updateJwt("bla");
+        try {
+            arangoDB.getVersion();
+            fail();
+        } catch (ArangoDBException e) {
+            assertThat(e.getResponseCode(), is(401));
+        } finally {
+            arangoDB.shutdown();
+        }
+
         arangoDB.shutdown();
     }
 

--- a/src/test/java/com/arangodb/JwtAuthTest.java
+++ b/src/test/java/com/arangodb/JwtAuthTest.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Michele Rastelli
@@ -79,11 +78,13 @@ public class JwtAuthTest {
 
     @Test
     public void updateJwt() {
-        assumeTrue("VST does not allow updating JWT", protocol != Protocol.VST);
         arangoDB = getBuilder()
                 .jwt(jwt)
                 .build();
         arangoDB.getVersion();
+        if (protocol == Protocol.VST) {
+            arangoDB.shutdown();
+        }
         arangoDB.updateJwt("bla");
         try {
             arangoDB.getVersion();

--- a/src/test/java/com/arangodb/JwtAuthTest.java
+++ b/src/test/java/com/arangodb/JwtAuthTest.java
@@ -101,6 +101,7 @@ public class JwtAuthTest {
     private ArangoDB.Builder getBuilder() {
         return new ArangoDB.Builder()
                 .useProtocol(protocol)
+                .jwt(null)          // unset credentials from properties file
                 .user(null)         // unset credentials from properties file
                 .password(null);    // unset credentials from properties file
     }

--- a/src/test/java/com/arangodb/async/ArangoDBTest.java
+++ b/src/test/java/com/arangodb/async/ArangoDBTest.java
@@ -426,7 +426,7 @@ public class ArangoDBTest {
 
     @Test
     public void authenticationFailPassword() throws InterruptedException {
-        final ArangoDBAsync arangoDB = new ArangoDBAsync.Builder().password("no").build();
+        final ArangoDBAsync arangoDB = new ArangoDBAsync.Builder().password("no").jwt(null).build();
         try {
             arangoDB.getVersion().get();
             fail();
@@ -437,7 +437,7 @@ public class ArangoDBTest {
 
     @Test
     public void authenticationFailUser() throws InterruptedException {
-        final ArangoDBAsync arangoDB = new ArangoDBAsync.Builder().user("no").build();
+        final ArangoDBAsync arangoDB = new ArangoDBAsync.Builder().user("no").jwt(null).build();
         try {
             arangoDB.getVersion().get();
             fail();

--- a/src/test/java/com/arangodb/async/JwtAuthTest.java
+++ b/src/test/java/com/arangodb/async/JwtAuthTest.java
@@ -1,0 +1,81 @@
+package com.arangodb.async;
+
+import com.arangodb.ArangoDB;
+import com.arangodb.ArangoDBException;
+import com.arangodb.util.ArangoSerialization;
+import com.arangodb.velocystream.Request;
+import com.arangodb.velocystream.RequestType;
+import com.arangodb.velocystream.Response;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class JwtAuthTest {
+
+    private static String jwt;
+    private ArangoDBAsync arangoDB;
+
+    @BeforeClass
+    public static void init() {
+        ArangoDB arangoDB = new ArangoDB.Builder().build();
+        jwt = getJwt(arangoDB);
+        arangoDB.shutdown();
+    }
+
+    @After
+    public void after() {
+        if (arangoDB != null)
+            arangoDB.shutdown();
+    }
+
+    @Test
+    public void notAuthenticated() throws InterruptedException {
+        arangoDB = getBuilder().build();
+        try {
+            arangoDB.getVersion().get();
+            fail();
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), is(instanceOf(ArangoDBException.class)));
+            assertThat(((ArangoDBException) e.getCause()).getResponseCode(), is(401));
+        }
+        arangoDB.shutdown();
+    }
+
+    @Test
+    public void authenticated() throws ExecutionException, InterruptedException {
+        arangoDB = getBuilder()
+                .jwt(jwt)
+                .build();
+        arangoDB.getVersion().get();
+        arangoDB.shutdown();
+    }
+
+    private ArangoDBAsync.Builder getBuilder() {
+        return new ArangoDBAsync.Builder()
+                .user(null)         // unset credentials from properties file
+                .password(null);    // unset credentials from properties file
+    }
+
+    private static String getJwt(ArangoDB arangoDB) {
+        ArangoSerialization serde = arangoDB.util();
+        Map<String, String> reqBody = new HashMap<>();
+        reqBody.put("username", "root");
+        reqBody.put("password", "test");
+
+        Request req = new Request("_system", RequestType.POST, "/_open/auth");
+        req.setBody(serde.serialize(reqBody));
+
+        Response resp = arangoDB.execute(req);
+        Map<String, String> respBody = serde.deserialize(resp.getBody(), Map.class);
+        return respBody.get("jwt");
+    }
+}

--- a/src/test/java/com/arangodb/async/JwtAuthTest.java
+++ b/src/test/java/com/arangodb/async/JwtAuthTest.java
@@ -81,6 +81,7 @@ public class JwtAuthTest {
 
     private ArangoDBAsync.Builder getBuilder() {
         return new ArangoDBAsync.Builder()
+                .jwt(null)          // unset credentials from properties file
                 .user(null)         // unset credentials from properties file
                 .password(null);    // unset credentials from properties file
     }

--- a/src/test/java/com/arangodb/async/JwtAuthTest.java
+++ b/src/test/java/com/arangodb/async/JwtAuthTest.java
@@ -59,6 +59,26 @@ public class JwtAuthTest {
         arangoDB.shutdown();
     }
 
+    @Test
+    public void updateJwt() throws ExecutionException, InterruptedException {
+        arangoDB = getBuilder()
+                .jwt(jwt)
+                .build();
+        arangoDB.getVersion().get();
+        arangoDB.updateJwt("bla");
+        try {
+            arangoDB.getVersion().get();
+            fail();
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), is(instanceOf(ArangoDBException.class)));
+            assertThat(((ArangoDBException) e.getCause()).getResponseCode(), is(401));
+        }
+
+        arangoDB.updateJwt(jwt);
+        arangoDB.getVersion().get();
+        arangoDB.shutdown();
+    }
+
     private ArangoDBAsync.Builder getBuilder() {
         return new ArangoDBAsync.Builder()
                 .user(null)         // unset credentials from properties file

--- a/src/test/java/com/arangodb/internal/HostHandlerTest.java
+++ b/src/test/java/com/arangodb/internal/HostHandlerTest.java
@@ -26,6 +26,7 @@ import com.arangodb.internal.net.*;
 import com.arangodb.util.ArangoSerialization;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,9 +39,31 @@ import static org.junit.Assert.fail;
  */
 public class HostHandlerTest {
 
-    private static final Host HOST_0 = new HostImpl(null, new HostDescription("127.0.0.1", 8529));
-    private static final Host HOST_1 = new HostImpl(null, new HostDescription("127.0.0.2", 8529));
-    private static final Host HOST_2 = new HostImpl(null, new HostDescription("127.0.0.3", 8529));
+    private static final ConnectionPool mockCP = new ConnectionPool() {
+        @Override
+        public Connection createConnection(HostDescription host) {
+            return null;
+        }
+
+        @Override
+        public Connection connection() {
+            return null;
+        }
+
+        @Override
+        public void setJwt(String jwt) {
+
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+    };
+
+    private static final Host HOST_0 = new HostImpl(mockCP, new HostDescription("127.0.0.1", 8529));
+    private static final Host HOST_1 = new HostImpl(mockCP, new HostDescription("127.0.0.2", 8529));
+    private static final Host HOST_2 = new HostImpl(mockCP, new HostDescription("127.0.0.3", 8529));
 
     private static final HostResolver SINGLE_HOST = new HostResolver() {
 


### PR DESCRIPTION
Implement support to JWT authentication for VST and HTTP connections, for sync and async variants. 

Create new API to:

    set the JWT token in configuration file (sync and async)

    set the JWT in the driver builder (sync and async)

    update the JWT at runtime (sync and async)

NOTE: in VST the JWT is checked only in the initial authentication request. Any follow-up requests over the same connection will not re-validate the JWT, therefore there is no need for the driver to close VST connections whose authentication JWT has expired.

doc PR: https://github.com/arangodb/docs/pull/856

---

fixes https://github.com/arangodb/arangodb-java-driver/issues/335