### PR TITLE
[DE-131] Bugfix activefailover concurrency

### DIFF
--- a/docker/start_db.sh
+++ b/docker/start_db.sh
@@ -96,3 +96,9 @@ for a in ${COORDINATORS[*]} ; do
     echo "$SCHEME://$a"
     echo ""
 done
+
+if [ "$STARTER_MODE" == "activefailover" ]; then
+  LEADER=$("$LOCATION"/find_active_endpoint.sh)
+  echo "Leader: $SCHEME://$LEADER"
+  echo ""
+fi

--- a/src/main/java/com/arangodb/async/internal/velocystream/VstCommunicationAsync.java
+++ b/src/main/java/com/arangodb/async/internal/velocystream/VstCommunicationAsync.java
@@ -85,8 +85,7 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
                         }
                         final String location = e.getLocation();
                         final HostDescription redirectHost = HostUtils.createFromLocation(location);
-                        hostHandler.closeCurrentOnError();
-                        hostHandler.fail(e);
+                        hostHandler.failIfNotMatch(redirectHost, e);
                         execute(request, new HostHandle().setHost(redirectHost), attemptCount + 1)
                                 .whenComplete((v, err) -> {
                                     if (v != null) {

--- a/src/main/java/com/arangodb/internal/http/HttpCommunication.java
+++ b/src/main/java/com/arangodb/internal/http/HttpCommunication.java
@@ -106,8 +106,7 @@ public class HttpCommunication implements Closeable {
             if (e instanceof ArangoDBRedirectException && attemptCount < 3) {
                 final String location = ((ArangoDBRedirectException) e).getLocation();
                 final HostDescription redirectHost = HostUtils.createFromLocation(location);
-                hostHandler.closeCurrentOnError();
-                hostHandler.fail(e);
+                hostHandler.failIfNotMatch(redirectHost, e);
                 return execute(request, new HostHandle().setHost(redirectHost), attemptCount + 1);
             } else {
                 throw e;

--- a/src/main/java/com/arangodb/internal/net/DirtyReadHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/DirtyReadHostHandler.java
@@ -61,6 +61,11 @@ public class DirtyReadHostHandler implements HostHandler {
     }
 
     @Override
+    public void failIfNotMatch(HostDescription host, Exception exception) {
+        determineHostHandler().failIfNotMatch(host, exception);
+    }
+
+    @Override
     public void reset() {
         determineHostHandler().reset();
     }
@@ -79,6 +84,11 @@ public class DirtyReadHostHandler implements HostHandler {
     @Override
     public void closeCurrentOnError() {
         determineHostHandler().closeCurrentOnError();
+    }
+
+    @Override
+    public void closeCurrentOnErrorIfNotMatch(HostDescription host) {
+        determineHostHandler().closeCurrentOnErrorIfNotMatch(host);
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/net/FallbackHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/FallbackHostHandler.java
@@ -80,6 +80,13 @@ public class FallbackHostHandler implements HostHandler {
     }
 
     @Override
+    public synchronized void failIfNotMatch(HostDescription host, Exception exception) {
+        if (!host.equals(current.getDescription())) {
+            fail(exception);
+        }
+    }
+
+    @Override
     public void reset() {
         iterations = 0;
         lastFailExceptions.clear();
@@ -102,6 +109,13 @@ public class FallbackHostHandler implements HostHandler {
     @Override
     public void closeCurrentOnError() {
         current.closeOnError();
+    }
+
+    @Override
+    public synchronized void closeCurrentOnErrorIfNotMatch(HostDescription host) {
+        if (!host.equals(current.getDescription())) {
+            closeCurrentOnError();
+        }
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/net/HostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/HostHandler.java
@@ -33,6 +33,8 @@ public interface HostHandler {
 
     void fail(Exception exception);
 
+    void failIfNotMatch(HostDescription host, Exception exception);
+
     void reset();
 
     void confirm();
@@ -40,6 +42,8 @@ public interface HostHandler {
     void close() throws IOException;
 
     void closeCurrentOnError();
+
+    void closeCurrentOnErrorIfNotMatch(HostDescription host);
 
     void setJwt(String jwt);
 

--- a/src/main/java/com/arangodb/internal/net/RandomHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RandomHostHandler.java
@@ -59,6 +59,13 @@ public class RandomHostHandler implements HostHandler {
         current = fallback.get(null, null);
     }
 
+    @Override
+    public synchronized void failIfNotMatch(HostDescription host, Exception exception) {
+        if (!host.equals(current.getDescription())) {
+            fail(exception);
+        }
+    }
+
     private Host getRandomHost(final boolean initial, final boolean closeConnections) {
         hosts = resolver.resolve(initial, closeConnections);
         final ArrayList<Host> hostList = new ArrayList<>(hosts.getHostsList());
@@ -83,6 +90,13 @@ public class RandomHostHandler implements HostHandler {
     @Override
     public void closeCurrentOnError() {
         current.closeOnError();
+    }
+
+    @Override
+    public synchronized void closeCurrentOnErrorIfNotMatch(HostDescription host) {
+        if (!host.equals(current.getDescription())) {
+            closeCurrentOnError();
+        }
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
+++ b/src/main/java/com/arangodb/internal/net/RoundRobinHostHandler.java
@@ -90,6 +90,11 @@ public class RoundRobinHostHandler implements HostHandler {
     }
 
     @Override
+    public void failIfNotMatch(HostDescription host, Exception exception) {
+        fail(exception);
+    }
+
+    @Override
     public void reset() {
         fails = 0;
         lastFailExceptions.clear();
@@ -107,6 +112,11 @@ public class RoundRobinHostHandler implements HostHandler {
     @Override
     public void closeCurrentOnError() {
         currentHost.closeOnError();
+    }
+
+    @Override
+    public void closeCurrentOnErrorIfNotMatch(HostDescription host) {
+        closeCurrentOnError();
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
@@ -151,7 +151,6 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
             }
             final String location = e.getLocation();
             final HostDescription redirectHost = HostUtils.createFromLocation(location);
-            hostHandler.closeCurrentOnErrorIfNotMatch(redirectHost);
             hostHandler.failIfNotMatch(redirectHost, e);
             return execute(request, new HostHandle().setHost(redirectHost), attemptCount + 1);
         }

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunicationSync.java
@@ -151,8 +151,8 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
             }
             final String location = e.getLocation();
             final HostDescription redirectHost = HostUtils.createFromLocation(location);
-            hostHandler.closeCurrentOnError();
-            hostHandler.fail(e);
+            hostHandler.closeCurrentOnErrorIfNotMatch(redirectHost);
+            hostHandler.failIfNotMatch(redirectHost, e);
             return execute(request, new HostHandle().setHost(redirectHost), attemptCount + 1);
         }
     }

--- a/src/test/java/com/arangodb/ConcurrencyTests.java
+++ b/src/test/java/com/arangodb/ConcurrencyTests.java
@@ -1,0 +1,42 @@
+package com.arangodb;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@RunWith(Parameterized.class)
+public class ConcurrencyTests {
+
+    final Protocol protocol;
+
+    public ConcurrencyTests(Protocol protocol) {
+        this.protocol = protocol;
+    }
+
+    @Parameterized.Parameters
+    public static Protocol[] protocols() {
+        return Protocol.values();
+    }
+
+    @Test
+    public void concurrentPendingRequests() throws ExecutionException, InterruptedException {
+        ArangoDB adb = new ArangoDB.Builder().useProtocol(protocol).build();
+        List<CompletableFuture<Void>> futures = IntStream.range(0, 10)
+                .mapToObj(i -> CompletableFuture.runAsync(
+                        () -> adb.db().query("RETURN SLEEP(1)", Void.class),
+                        Executors.newFixedThreadPool(10))
+                )
+                .collect(Collectors.toList());
+        for (CompletableFuture<Void> f : futures) {
+            f.get();
+        }
+    }
+
+}

--- a/src/test/java/com/arangodb/ConcurrencyTests.java
+++ b/src/test/java/com/arangodb/ConcurrencyTests.java
@@ -37,6 +37,7 @@ public class ConcurrencyTests {
         for (CompletableFuture<Void> f : futures) {
             f.get();
         }
+        adb.shutdown();
     }
 
 }

--- a/src/test/java/com/arangodb/async/ConcurrencyTests.java
+++ b/src/test/java/com/arangodb/async/ConcurrencyTests.java
@@ -1,0 +1,24 @@
+package com.arangodb.async;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ConcurrencyTests {
+
+    @Test
+    public void concurrentPendingRequests() throws ExecutionException, InterruptedException {
+        ArangoDBAsync adb = new ArangoDBAsync.Builder().build();
+        List<CompletableFuture<ArangoCursorAsync<Void>>> reqs = IntStream.range(0, 10)
+                .mapToObj(__ -> adb.db().query("RETURN SLEEP(1)", Void.class))
+                .collect(Collectors.toList());
+        for (CompletableFuture<ArangoCursorAsync<Void>> req : reqs) {
+            req.get();
+        }
+    }
+
+}

--- a/src/test/java/com/arangodb/async/ConcurrencyTests.java
+++ b/src/test/java/com/arangodb/async/ConcurrencyTests.java
@@ -19,6 +19,7 @@ public class ConcurrencyTests {
         for (CompletableFuture<ArangoCursorAsync<Void>> req : reqs) {
             req.get();
         }
+        adb.shutdown();
     }
 
 }


### PR DESCRIPTION
This PR fixes concurrency problems happening during the failover to a new activefailover leader, i.e. there are concurrent or pending requests on the connections to the old leader.