### PR TITLE
[Feature] Deduplicate in PersistentIndex

### DIFF
--- a/src/main/java/com/arangodb/model/PersistentIndexOptions.java
+++ b/src/main/java/com/arangodb/model/PersistentIndexOptions.java
@@ -33,6 +33,7 @@ public class PersistentIndexOptions extends IndexOptions<PersistentIndexOptions>
     protected final IndexType type = IndexType.persistent;
     private Boolean unique;
     private Boolean sparse;
+    private Boolean deduplicate;
     private Boolean estimates;
 
     public PersistentIndexOptions() {
@@ -85,6 +86,20 @@ public class PersistentIndexOptions extends IndexOptions<PersistentIndexOptions>
      */
     public PersistentIndexOptions sparse(final Boolean sparse) {
         this.sparse = sparse;
+        return this;
+    }
+
+    public Boolean getDeduplicate() {
+        return deduplicate;
+    }
+
+    /**
+     * @param deduplicate
+     *         if false, the deduplication of array values is turned off.
+     * @return options
+     */
+    public PersistentIndexOptions deduplicate(final Boolean deduplicate) {
+        this.deduplicate = deduplicate;
         return this;
     }
 

--- a/src/main/java/com/arangodb/model/PersistentIndexOptions.java
+++ b/src/main/java/com/arangodb/model/PersistentIndexOptions.java
@@ -95,7 +95,7 @@ public class PersistentIndexOptions extends IndexOptions<PersistentIndexOptions>
 
     /**
      * @param deduplicate
-     *         if false, the deduplication of array values is turned off.
+     *         if false, the deduplication of array values is turned off. Default: {@code true}
      * @return options
      */
     public PersistentIndexOptions deduplicate(final Boolean deduplicate) {

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -1468,6 +1468,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         assertThat(indexResult.getSparse()).isFalse();
         assertThat(indexResult.getType()).isEqualTo(IndexType.persistent);
         assertThat(indexResult.getUnique()).isFalse();
+        assertThat(indexResult.getDeduplicate()).isTrue();
     }
 
     @ParameterizedTest(name = "{index}")
@@ -1594,7 +1595,6 @@ class ArangoCollectionTest extends BaseJunit5 {
     @MethodSource("cols")
     void indexDeduplicate(ArangoCollection collection) {
         assumeTrue(isAtLeastVersion(3, 8));
-        assumeTrue(isSingleServer());
 
         String name = "persistentIndex-" + rnd();
         final PersistentIndexOptions options = new PersistentIndexOptions();
@@ -1608,14 +1608,12 @@ class ArangoCollectionTest extends BaseJunit5 {
         final IndexEntity indexResult = collection.ensurePersistentIndex(fields, options);
         assertThat(indexResult).isNotNull();
         assertThat(indexResult.getDeduplicate()).isTrue();
-        assertThat(indexResult.getSelectivityEstimate()).isNotNull();
     }
 
     @ParameterizedTest(name = "{index}")
     @MethodSource("cols")
     void indexDeduplicateFalse(ArangoCollection collection) {
         assumeTrue(isAtLeastVersion(3, 8));
-        assumeTrue(isSingleServer());
 
         String name = "persistentIndex-" + rnd();
         final PersistentIndexOptions options = new PersistentIndexOptions();
@@ -1629,7 +1627,6 @@ class ArangoCollectionTest extends BaseJunit5 {
         final IndexEntity indexResult = collection.ensurePersistentIndex(fields, options);
         assertThat(indexResult).isNotNull();
         assertThat(indexResult.getDeduplicate()).isFalse();
-        assertThat(indexResult.getSelectivityEstimate()).isNull();
     }
 
     @ParameterizedTest(name = "{index}")

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -1592,6 +1592,48 @@ class ArangoCollectionTest extends BaseJunit5 {
 
     @ParameterizedTest(name = "{index}")
     @MethodSource("cols")
+    void indexDeduplicate(ArangoCollection collection) {
+        assumeTrue(isAtLeastVersion(3, 8));
+        assumeTrue(isSingleServer());
+
+        String name = "persistentIndex-" + rnd();
+        final PersistentIndexOptions options = new PersistentIndexOptions();
+        options.name(name);
+        options.deduplicate(true);
+
+        String f1 = "field-" + rnd();
+        String f2 = "field-" + rnd();
+
+        final Collection<String> fields = Arrays.asList(f1, f2);
+        final IndexEntity indexResult = collection.ensurePersistentIndex(fields, options);
+        assertThat(indexResult).isNotNull();
+        assertThat(indexResult.getDeduplicate()).isTrue();
+        assertThat(indexResult.getSelectivityEstimate()).isNotNull();
+    }
+
+    @ParameterizedTest(name = "{index}")
+    @MethodSource("cols")
+    void indexDeduplicateFalse(ArangoCollection collection) {
+        assumeTrue(isAtLeastVersion(3, 8));
+        assumeTrue(isSingleServer());
+
+        String name = "persistentIndex-" + rnd();
+        final PersistentIndexOptions options = new PersistentIndexOptions();
+        options.name(name);
+        options.deduplicate(false);
+
+        String f1 = "field-" + rnd();
+        String f2 = "field-" + rnd();
+
+        final Collection<String> fields = Arrays.asList(f1, f2);
+        final IndexEntity indexResult = collection.ensurePersistentIndex(fields, options);
+        assertThat(indexResult).isNotNull();
+        assertThat(indexResult.getDeduplicate()).isFalse();
+        assertThat(indexResult.getSelectivityEstimate()).isNull();
+    }
+
+    @ParameterizedTest(name = "{index}")
+    @MethodSource("cols")
     void createFulltextIndex(ArangoCollection collection) {
         String f1 = "field-" + rnd();
         final Collection<String> fields = Collections.singletonList(f1);

--- a/src/test/java/com/arangodb/async/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/async/ArangoCollectionTest.java
@@ -1009,6 +1009,7 @@ class ArangoCollectionTest extends BaseTest {
                     assertThat(indexResult.getSparse()).isEqualTo(false);
                     assertThat(indexResult.getType()).isEqualTo(IndexType.persistent);
                     assertThat(indexResult.getUnique()).isEqualTo(false);
+                    assertThat(indexResult.getDeduplicate()).isTrue();
                 })
                 .get();
     }
@@ -1034,6 +1035,42 @@ class ArangoCollectionTest extends BaseTest {
         assertThat(indexResult.getType()).isEqualTo(IndexType.persistent);
         assertThat(indexResult.getUnique()).isFalse();
         assertThat(indexResult.getName()).isEqualTo("myPersistentIndex");
+    }
+
+    @Test
+    void indexDeduplicate() throws ExecutionException, InterruptedException {
+        assumeTrue(isAtLeastVersion(3, 8));
+
+        String name = "persistentIndex-" + rnd();
+        final PersistentIndexOptions options = new PersistentIndexOptions();
+        options.name(name);
+        options.deduplicate(true);
+
+        String f1 = "field-" + rnd();
+        String f2 = "field-" + rnd();
+
+        final Collection<String> fields = Arrays.asList(f1, f2);
+        final IndexEntity indexResult = db.collection(COLLECTION_NAME).ensurePersistentIndex(fields, options).get();
+        assertThat(indexResult).isNotNull();
+        assertThat(indexResult.getDeduplicate()).isTrue();
+    }
+
+    @Test
+    void indexDeduplicateFalse() throws ExecutionException, InterruptedException {
+        assumeTrue(isAtLeastVersion(3, 8));
+
+        String name = "persistentIndex-" + rnd();
+        final PersistentIndexOptions options = new PersistentIndexOptions();
+        options.name(name);
+        options.deduplicate(false);
+
+        String f1 = "field-" + rnd();
+        String f2 = "field-" + rnd();
+
+        final Collection<String> fields = Arrays.asList(f1, f2);
+        final IndexEntity indexResult = db.collection(COLLECTION_NAME).ensurePersistentIndex(fields, options).get();
+        assertThat(indexResult).isNotNull();
+        assertThat(indexResult.getDeduplicate()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Hello, Please accept my pull request.

I'm submitting the fix to include the option to change the state of deduplicate in the persistent index.

Documentation:
<https://www.arangodb.com/docs/stable/indexing-index-basics.html#persistent-index>

I need this fix to fix spring-data-arango as well.

Thank you for your attention.