### PR TITLE
[DE-216] field annotations

### DIFF
--- a/src/main/java/com/arangodb/ArangoDB.java
+++ b/src/main/java/com/arangodb/ArangoDB.java
@@ -660,10 +660,7 @@ public interface ArangoDB extends ArangoSerializationAccessor {
          *
          * @param serialization custom serializer/deserializer
          * @return {@link ArangoDB.Builder}
-         * @deprecated Use {@link com.arangodb.mapping.ArangoJack} instead and register custom serializers and deserializers by implementing {@link com.fasterxml.jackson.databind.JsonSerializer} and {@link com.fasterxml.jackson.databind.JsonDeserializer}.
-         * @see <a href="https://www.arangodb.com/docs/stable/drivers/java-reference-serialization.html#custom-serializer">Reference Documentation</a>
          */
-        @Deprecated
         public Builder serializer(final ArangoSerialization serialization) {
             setSerializer(serialization);
             return this;

--- a/src/main/java/com/arangodb/async/ArangoDBAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoDBAsync.java
@@ -846,10 +846,7 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
          *
          * @param serialization custom serializer/deserializer
          * @return {@link ArangoDBAsync.Builder}
-         * @deprecated Use {@link com.arangodb.mapping.ArangoJack} instead and register custom serializers and deserializers by implementing {@link com.fasterxml.jackson.databind.JsonSerializer} and {@link com.fasterxml.jackson.databind.JsonDeserializer}.
-         * @see <a href="https://www.arangodb.com/docs/stable/drivers/java-reference-serialization.html#custom-serializer">Reference Documentation</a>
          */
-        @Deprecated
         public Builder serializer(final ArangoSerialization serialization) {
             setSerializer(serialization);
             return this;

--- a/src/main/java/com/arangodb/entity/BaseDocument.java
+++ b/src/main/java/com/arangodb/entity/BaseDocument.java
@@ -20,7 +20,7 @@
 
 package com.arangodb.entity;
 
-import com.arangodb.entity.DocumentField.Type;
+import com.arangodb.internal.DocumentFields;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -33,11 +33,11 @@ public class BaseDocument implements Serializable {
 
     private static final long serialVersionUID = -1824742667228719116L;
 
-    @DocumentField(Type.ID)
+    @Id
     protected String id;
-    @DocumentField(Type.KEY)
+    @Key
     protected String key;
-    @DocumentField(Type.REV)
+    @Rev
     protected String revision;
     protected Map<String, Object> properties;
 
@@ -53,15 +53,15 @@ public class BaseDocument implements Serializable {
 
     public BaseDocument(final Map<String, Object> properties) {
         this();
-        final Object tmpId = properties.remove(DocumentField.Type.ID.getSerializeName());
+        final Object tmpId = properties.remove(DocumentFields.ID);
         if (tmpId != null) {
             id = tmpId.toString();
         }
-        final Object tmpKey = properties.remove(DocumentField.Type.KEY.getSerializeName());
+        final Object tmpKey = properties.remove(DocumentFields.KEY);
         if (tmpKey != null) {
             key = tmpKey.toString();
         }
-        final Object tmpRev = properties.remove(DocumentField.Type.REV.getSerializeName());
+        final Object tmpRev = properties.remove(DocumentFields.REV);
         if (tmpRev != null) {
             revision = tmpRev.toString();
         }

--- a/src/main/java/com/arangodb/entity/BaseEdgeDocument.java
+++ b/src/main/java/com/arangodb/entity/BaseEdgeDocument.java
@@ -20,7 +20,7 @@
 
 package com.arangodb.entity;
 
-import com.arangodb.entity.DocumentField.Type;
+import com.arangodb.internal.DocumentFields;
 
 import java.util.Map;
 
@@ -31,9 +31,9 @@ public class BaseEdgeDocument extends BaseDocument {
 
     private static final long serialVersionUID = 6904923804449368783L;
 
-    @DocumentField(Type.FROM)
+    @From
     private String from;
-    @DocumentField(Type.TO)
+    @To
     private String to;
 
     public BaseEdgeDocument() {
@@ -54,11 +54,11 @@ public class BaseEdgeDocument extends BaseDocument {
 
     public BaseEdgeDocument(final Map<String, Object> properties) {
         super(properties);
-        final Object tmpFrom = properties.remove(DocumentField.Type.FROM.getSerializeName());
+        final Object tmpFrom = properties.remove(DocumentFields.FROM);
         if (tmpFrom != null) {
             from = tmpFrom.toString();
         }
-        final Object tmpTo = properties.remove(DocumentField.Type.TO.getSerializeName());
+        final Object tmpTo = properties.remove(DocumentFields.TO);
         if (tmpTo != null) {
             to = tmpTo.toString();
         }

--- a/src/main/java/com/arangodb/entity/DocumentEntity.java
+++ b/src/main/java/com/arangodb/entity/DocumentEntity.java
@@ -20,18 +20,16 @@
 
 package com.arangodb.entity;
 
-import com.arangodb.entity.DocumentField.Type;
-
 /**
  * @author Mark Vollmary
  */
 public class DocumentEntity implements Entity {
 
-    @DocumentField(Type.KEY)
+    @Key
     private String key;
-    @DocumentField(Type.ID)
+    @Id
     private String id;
-    @DocumentField(Type.REV)
+    @Rev
     private String rev;
 
     public DocumentEntity() {

--- a/src/main/java/com/arangodb/entity/DocumentField.java
+++ b/src/main/java/com/arangodb/entity/DocumentField.java
@@ -27,13 +27,45 @@ import java.lang.annotation.Target;
 
 /**
  * @author Mark Vollmary
+ * @deprecated Use {@link Id}, {@link Key}, {@link Rev}, {@link From} or {@link To} instead.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})
+@Deprecated
 public @interface DocumentField {
 
+    @Deprecated
     enum Type {
-        ID("_id"), KEY("_key"), REV("_rev"), FROM("_from"), TO("_to");
+
+        /**
+         * @deprecated Use {@link Id} instead.
+         */
+        @Deprecated
+        ID("_id"),
+
+        /**
+         * @deprecated Use {@link Key} instead.
+         */
+        @Deprecated
+        KEY("_key"),
+
+        /**
+         * @deprecated Use {@link Rev} instead.
+         */
+        @Deprecated
+        REV("_rev"),
+
+        /**
+         * @deprecated Use {@link From} instead.
+         */
+        @Deprecated
+        FROM("_from"),
+
+        /**
+         * @deprecated Use {@link To} instead.
+         */
+        @Deprecated
+        TO("_to");
 
         private final String serializeName;
 

--- a/src/main/java/com/arangodb/entity/From.java
+++ b/src/main/java/com/arangodb/entity/From.java
@@ -1,0 +1,23 @@
+package com.arangodb.entity;
+
+import com.arangodb.internal.DocumentFields;
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Michele Rastelli
+ */
+// TODO: in v7 add targets ElementType.METHOD and ElementType.PARAMETER
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotationsInside
+@JsonProperty(DocumentFields.FROM)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public @interface From {
+}

--- a/src/main/java/com/arangodb/entity/Id.java
+++ b/src/main/java/com/arangodb/entity/Id.java
@@ -1,0 +1,23 @@
+package com.arangodb.entity;
+
+import com.arangodb.internal.DocumentFields;
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Michele Rastelli
+ */
+// TODO: in v7 add targets ElementType.METHOD and ElementType.PARAMETER
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotationsInside
+@JsonProperty(DocumentFields.ID)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public @interface Id {
+}

--- a/src/main/java/com/arangodb/entity/Key.java
+++ b/src/main/java/com/arangodb/entity/Key.java
@@ -1,0 +1,23 @@
+package com.arangodb.entity;
+
+import com.arangodb.internal.DocumentFields;
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Michele Rastelli
+ */
+// TODO: in v7 add targets ElementType.METHOD and ElementType.PARAMETER
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotationsInside
+@JsonProperty(DocumentFields.KEY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public @interface Key {
+}

--- a/src/main/java/com/arangodb/entity/Rev.java
+++ b/src/main/java/com/arangodb/entity/Rev.java
@@ -1,0 +1,23 @@
+package com.arangodb.entity;
+
+import com.arangodb.internal.DocumentFields;
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Michele Rastelli
+ */
+// TODO: in v7 add targets ElementType.METHOD and ElementType.PARAMETER
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotationsInside
+@JsonProperty(DocumentFields.REV)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public @interface Rev {
+}

--- a/src/main/java/com/arangodb/entity/To.java
+++ b/src/main/java/com/arangodb/entity/To.java
@@ -1,0 +1,23 @@
+package com.arangodb.entity;
+
+import com.arangodb.internal.DocumentFields;
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Michele Rastelli
+ */
+// TODO: in v7 add targets ElementType.METHOD and ElementType.PARAMETER
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotationsInside
+@JsonProperty(DocumentFields.TO)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public @interface To {
+}

--- a/src/main/java/com/arangodb/internal/DocumentFields.java
+++ b/src/main/java/com/arangodb/internal/DocumentFields.java
@@ -1,0 +1,20 @@
+package com.arangodb.internal;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class DocumentFields {
+
+    private DocumentFields() {
+    }
+
+    public static final String ID = "_id";
+    public static final String KEY = "_key";
+    public static final String REV = "_rev";
+    public static final String FROM = "_from";
+    public static final String TO = "_to";
+
+    public static List<String> values() {
+        return Arrays.asList(ID, KEY, REV, FROM, TO);
+    }
+}

--- a/src/main/java/com/arangodb/internal/InternalArangoCollection.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoCollection.java
@@ -111,10 +111,10 @@ public abstract class InternalArangoCollection<A extends InternalArangoDB<E>, D 
                 doc.setOld(util(Serializer.CUSTOM).deserialize(oldDoc, value.getClass()));
             }
             if (options == null || Boolean.TRUE != options.getSilent()) {
-                final Map<DocumentField.Type, String> values = new HashMap<>();
-                values.put(DocumentField.Type.ID, doc.getId());
-                values.put(DocumentField.Type.KEY, doc.getKey());
-                values.put(DocumentField.Type.REV, doc.getRev());
+                final Map<String, String> values = new HashMap<>();
+                values.put(DocumentFields.ID, doc.getId());
+                values.put(DocumentFields.KEY, doc.getKey());
+                values.put(DocumentFields.REV, doc.getRev());
                 executor.documentCache().setValues(value, values);
             }
             return doc;
@@ -282,8 +282,8 @@ public abstract class InternalArangoCollection<A extends InternalArangoDB<E>, D 
                 doc.setOld(util(Serializer.CUSTOM).deserialize(oldDoc, value.getClass()));
             }
             if (options == null || Boolean.TRUE != options.getSilent()) {
-                final Map<DocumentField.Type, String> values = new HashMap<>();
-                values.put(DocumentField.Type.REV, doc.getRev());
+                final Map<String, String> values = new HashMap<>();
+                values.put(DocumentFields.REV, doc.getRev());
                 executor.documentCache().setValues(value, values);
             }
             return doc;
@@ -380,8 +380,8 @@ public abstract class InternalArangoCollection<A extends InternalArangoDB<E>, D 
                 doc.setOld(util(Serializer.CUSTOM).deserialize(oldDoc, returnType));
             }
             if (options == null || Boolean.TRUE != options.getSilent()) {
-                final Map<DocumentField.Type, String> values = new HashMap<>();
-                values.put(DocumentField.Type.REV, doc.getRev());
+                final Map<String, String> values = new HashMap<>();
+                values.put(DocumentFields.REV, doc.getRev());
                 executor.documentCache().setValues(value, values);
             }
             return doc;

--- a/src/main/java/com/arangodb/internal/InternalArangoEdgeCollection.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoEdgeCollection.java
@@ -20,7 +20,6 @@
 
 package com.arangodb.internal;
 
-import com.arangodb.entity.DocumentField;
 import com.arangodb.entity.EdgeEntity;
 import com.arangodb.entity.EdgeUpdateEntity;
 import com.arangodb.internal.ArangoExecutor.ResponseDeserializer;
@@ -78,10 +77,10 @@ public abstract class InternalArangoEdgeCollection<A extends InternalArangoDB<E>
         return response -> {
             final VPackSlice body = response.getBody().get(EDGE);
             final EdgeEntity doc = util().deserialize(body, EdgeEntity.class);
-            final Map<DocumentField.Type, String> values = new HashMap<>();
-            values.put(DocumentField.Type.ID, doc.getId());
-            values.put(DocumentField.Type.KEY, doc.getKey());
-            values.put(DocumentField.Type.REV, doc.getRev());
+            final Map<String, String> values = new HashMap<>();
+            values.put(DocumentFields.ID, doc.getId());
+            values.put(DocumentFields.KEY, doc.getKey());
+            values.put(DocumentFields.REV, doc.getRev());
             executor.documentCache().setValues(value, values);
             return doc;
         };
@@ -119,8 +118,8 @@ public abstract class InternalArangoEdgeCollection<A extends InternalArangoDB<E>
         return response -> {
             final VPackSlice body = response.getBody().get(EDGE);
             final EdgeUpdateEntity doc = util().deserialize(body, EdgeUpdateEntity.class);
-            final Map<DocumentField.Type, String> values = new HashMap<>();
-            values.put(DocumentField.Type.REV, doc.getRev());
+            final Map<String, String> values = new HashMap<>();
+            values.put(DocumentFields.REV, doc.getRev());
             executor.documentCache().setValues(value, values);
             return doc;
         };
@@ -144,8 +143,8 @@ public abstract class InternalArangoEdgeCollection<A extends InternalArangoDB<E>
         return response -> {
             final VPackSlice body = response.getBody().get(EDGE);
             final EdgeUpdateEntity doc = util().deserialize(body, EdgeUpdateEntity.class);
-            final Map<DocumentField.Type, String> values = new HashMap<>();
-            values.put(DocumentField.Type.REV, doc.getRev());
+            final Map<String, String> values = new HashMap<>();
+            values.put(DocumentFields.REV, doc.getRev());
             executor.documentCache().setValues(value, values);
             return doc;
         };

--- a/src/main/java/com/arangodb/internal/InternalArangoVertexCollection.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoVertexCollection.java
@@ -20,7 +20,6 @@
 
 package com.arangodb.internal;
 
-import com.arangodb.entity.DocumentField;
 import com.arangodb.entity.VertexEntity;
 import com.arangodb.entity.VertexUpdateEntity;
 import com.arangodb.internal.ArangoExecutor.ResponseDeserializer;
@@ -82,10 +81,10 @@ public abstract class InternalArangoVertexCollection<A extends InternalArangoDB<
         return response -> {
             final VPackSlice body = response.getBody().get(VERTEX);
             final VertexEntity doc = util().deserialize(body, VertexEntity.class);
-            final Map<DocumentField.Type, String> values = new HashMap<>();
-            values.put(DocumentField.Type.ID, doc.getId());
-            values.put(DocumentField.Type.KEY, doc.getKey());
-            values.put(DocumentField.Type.REV, doc.getRev());
+            final Map<String, String> values = new HashMap<>();
+            values.put(DocumentFields.ID, doc.getId());
+            values.put(DocumentFields.KEY, doc.getKey());
+            values.put(DocumentFields.REV, doc.getRev());
             executor.documentCache().setValues(value, values);
             return doc;
         };
@@ -123,8 +122,8 @@ public abstract class InternalArangoVertexCollection<A extends InternalArangoDB<
         return response -> {
             final VPackSlice body = response.getBody().get(VERTEX);
             final VertexUpdateEntity doc = util().deserialize(body, VertexUpdateEntity.class);
-            final Map<DocumentField.Type, String> values = new HashMap<>();
-            values.put(DocumentField.Type.REV, doc.getRev());
+            final Map<String, String> values = new HashMap<>();
+            values.put(DocumentFields.REV, doc.getRev());
             executor.documentCache().setValues(value, values);
             return doc;
         };
@@ -148,8 +147,8 @@ public abstract class InternalArangoVertexCollection<A extends InternalArangoDB<
         return response -> {
             final VPackSlice body = response.getBody().get(VERTEX);
             final VertexUpdateEntity doc = util().deserialize(body, VertexUpdateEntity.class);
-            final Map<DocumentField.Type, String> values = new HashMap<>();
-            values.put(DocumentField.Type.REV, doc.getRev());
+            final Map<String, String> values = new HashMap<>();
+            values.put(DocumentFields.REV, doc.getRev());
             executor.documentCache().setValues(value, values);
             return doc;
         };

--- a/src/main/java/com/arangodb/internal/mapping/VPackSerializers.java
+++ b/src/main/java/com/arangodb/internal/mapping/VPackSerializers.java
@@ -23,7 +23,7 @@ package com.arangodb.internal.mapping;
 
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.entity.BaseEdgeDocument;
-import com.arangodb.entity.DocumentField;
+import com.arangodb.internal.DocumentFields;
 import com.arangodb.jackson.dataformat.velocypack.internal.VPackGenerator;
 import com.arangodb.velocypack.VPackSlice;
 import com.arangodb.velocypack.internal.util.DateUtil;
@@ -85,9 +85,9 @@ public class VPackSerializers {
                 throws IOException {
             final Map<String, Object> doc = new HashMap<>();
             doc.putAll(value.getProperties());
-            doc.put(DocumentField.Type.ID.getSerializeName(), value.getId());
-            doc.put(DocumentField.Type.KEY.getSerializeName(), value.getKey());
-            doc.put(DocumentField.Type.REV.getSerializeName(), value.getRevision());
+            doc.put(DocumentFields.ID, value.getId());
+            doc.put(DocumentFields.KEY, value.getKey());
+            doc.put(DocumentFields.REV, value.getRevision());
             gen.writeObject(doc);
         }
     };
@@ -100,11 +100,11 @@ public class VPackSerializers {
                 final SerializerProvider serializers) throws IOException {
             final Map<String, Object> doc = new HashMap<>();
             doc.putAll(value.getProperties());
-            doc.put(DocumentField.Type.ID.getSerializeName(), value.getId());
-            doc.put(DocumentField.Type.KEY.getSerializeName(), value.getKey());
-            doc.put(DocumentField.Type.REV.getSerializeName(), value.getRevision());
-            doc.put(DocumentField.Type.FROM.getSerializeName(), value.getFrom());
-            doc.put(DocumentField.Type.TO.getSerializeName(), value.getTo());
+            doc.put(DocumentFields.ID, value.getId());
+            doc.put(DocumentFields.KEY, value.getKey());
+            doc.put(DocumentFields.REV, value.getRevision());
+            doc.put(DocumentFields.FROM, value.getFrom());
+            doc.put(DocumentFields.TO, value.getTo());
             gen.writeObject(doc);
         }
     };

--- a/src/main/java/com/arangodb/internal/velocypack/VPackDriverModule.java
+++ b/src/main/java/com/arangodb/internal/velocypack/VPackDriverModule.java
@@ -26,6 +26,7 @@ import com.arangodb.entity.arangosearch.ArangoSearchPropertiesEntity;
 import com.arangodb.entity.arangosearch.ConsolidationPolicy;
 import com.arangodb.entity.arangosearch.ConsolidationType;
 import com.arangodb.entity.arangosearch.analyzer.SearchAnalyzer;
+import com.arangodb.internal.DocumentFields;
 import com.arangodb.internal.velocystream.internal.AuthenticationRequest;
 import com.arangodb.internal.velocystream.internal.JwtAuthenticationRequest;
 import com.arangodb.model.CollectionSchema;
@@ -39,6 +40,7 @@ import com.arangodb.velocypack.VPackSetupContext;
 import com.arangodb.velocystream.Request;
 import com.arangodb.velocystream.Response;
 
+import java.lang.annotation.Annotation;
 import java.util.Date;
 
 /**
@@ -49,9 +51,20 @@ public class VPackDriverModule implements VPackModule, VPackParserModule {
     @Override
     public <C extends VPackSetupContext<C>> void setup(final C context) {
         context.fieldNamingStrategy(field -> {
-            final DocumentField annotation = field.getAnnotation(DocumentField.class);
-            if (annotation != null) {
-                return annotation.value().getSerializeName();
+            for (Annotation annotation : field.getAnnotations()) {
+                if(annotation instanceof DocumentField) {
+                    return ((DocumentField) annotation).value().getSerializeName();
+                } else if (annotation instanceof Id) {
+                    return DocumentFields.ID;
+                } else if (annotation instanceof Key) {
+                    return DocumentFields.KEY;
+                } else if (annotation instanceof Rev) {
+                    return DocumentFields.REV;
+                } else if (annotation instanceof From) {
+                    return DocumentFields.FROM;
+                } else if (annotation instanceof To) {
+                    return DocumentFields.TO;
+                }
             }
             return field.getName();
         });

--- a/src/main/java/com/arangodb/internal/velocypack/VPackSerializers.java
+++ b/src/main/java/com/arangodb/internal/velocypack/VPackSerializers.java
@@ -20,23 +20,9 @@
 
 package com.arangodb.internal.velocypack;
 
-import com.arangodb.entity.BaseDocument;
-import com.arangodb.entity.BaseEdgeDocument;
-import com.arangodb.entity.CollectionType;
-import com.arangodb.entity.DocumentField;
-import com.arangodb.entity.LogLevel;
-import com.arangodb.entity.MinReplicationFactor;
-import com.arangodb.entity.Permissions;
-import com.arangodb.entity.ReplicationFactor;
-import com.arangodb.entity.ViewType;
-import com.arangodb.entity.arangosearch.ArangoSearchCompression;
-import com.arangodb.entity.arangosearch.ArangoSearchProperties;
-import com.arangodb.entity.arangosearch.CollectionLink;
-import com.arangodb.entity.arangosearch.ConsolidationType;
-import com.arangodb.entity.arangosearch.FieldLink;
-import com.arangodb.entity.arangosearch.PrimarySort;
-import com.arangodb.entity.arangosearch.StoreValuesType;
-import com.arangodb.entity.arangosearch.StoredValue;
+import com.arangodb.entity.*;
+import com.arangodb.entity.arangosearch.*;
+import com.arangodb.internal.DocumentFields;
 import com.arangodb.internal.velocystream.internal.AuthenticationRequest;
 import com.arangodb.internal.velocystream.internal.JwtAuthenticationRequest;
 import com.arangodb.model.CollectionSchema;
@@ -44,11 +30,7 @@ import com.arangodb.model.TraversalOptions;
 import com.arangodb.model.TraversalOptions.Order;
 import com.arangodb.model.ZKDIndexOptions;
 import com.arangodb.model.arangosearch.ArangoSearchPropertiesOptions;
-import com.arangodb.velocypack.VPackBuilder;
-import com.arangodb.velocypack.VPackParser;
-import com.arangodb.velocypack.VPackSerializer;
-import com.arangodb.velocypack.VPackSlice;
-import com.arangodb.velocypack.ValueType;
+import com.arangodb.velocypack.*;
 import com.arangodb.velocystream.Request;
 
 import java.util.Collection;
@@ -105,19 +87,19 @@ public class VPackSerializers {
 
     public static final VPackSerializer<BaseDocument> BASE_DOCUMENT = (builder, attribute, value, context) -> {
         final Map<String, Object> doc = new HashMap<>(value.getProperties());
-        doc.put(DocumentField.Type.ID.getSerializeName(), value.getId());
-        doc.put(DocumentField.Type.KEY.getSerializeName(), value.getKey());
-        doc.put(DocumentField.Type.REV.getSerializeName(), value.getRevision());
+        doc.put(DocumentFields.ID, value.getId());
+        doc.put(DocumentFields.KEY, value.getKey());
+        doc.put(DocumentFields.REV, value.getRevision());
         context.serialize(builder, attribute, doc);
     };
 
     public static final VPackSerializer<BaseEdgeDocument> BASE_EDGE_DOCUMENT = (builder, attribute, value, context) -> {
         final Map<String, Object> doc = new HashMap<>(value.getProperties());
-        doc.put(DocumentField.Type.ID.getSerializeName(), value.getId());
-        doc.put(DocumentField.Type.KEY.getSerializeName(), value.getKey());
-        doc.put(DocumentField.Type.REV.getSerializeName(), value.getRevision());
-        doc.put(DocumentField.Type.FROM.getSerializeName(), value.getFrom());
-        doc.put(DocumentField.Type.TO.getSerializeName(), value.getTo());
+        doc.put(DocumentFields.ID, value.getId());
+        doc.put(DocumentFields.KEY, value.getKey());
+        doc.put(DocumentFields.REV, value.getRevision());
+        doc.put(DocumentFields.FROM, value.getFrom());
+        doc.put(DocumentFields.TO, value.getTo());
         context.serialize(builder, attribute, doc);
     };
 

--- a/src/test/java/com/arangodb/async/example/graph/Circle.java
+++ b/src/test/java/com/arangodb/async/example/graph/Circle.java
@@ -20,8 +20,9 @@
 
 package com.arangodb.async.example.graph;
 
-import com.arangodb.entity.DocumentField;
-import com.arangodb.entity.DocumentField.Type;
+import com.arangodb.entity.Id;
+import com.arangodb.entity.Key;
+import com.arangodb.entity.Rev;
 
 /**
  * @author a-brandt
@@ -29,13 +30,13 @@ import com.arangodb.entity.DocumentField.Type;
 @SuppressWarnings({"WeakerAccess", "unused"})
 class Circle {
 
-    @DocumentField(Type.ID)
+    @Id
     private String id;
 
-    @DocumentField(Type.KEY)
+    @Key
     private String key;
 
-    @DocumentField(Type.REV)
+    @Rev
     private String revision;
 
     private String label;

--- a/src/test/java/com/arangodb/async/example/graph/CircleEdge.java
+++ b/src/test/java/com/arangodb/async/example/graph/CircleEdge.java
@@ -20,8 +20,7 @@
 
 package com.arangodb.async.example.graph;
 
-import com.arangodb.entity.DocumentField;
-import com.arangodb.entity.DocumentField.Type;
+import com.arangodb.entity.*;
 
 /**
  * @author a-brandt
@@ -29,19 +28,19 @@ import com.arangodb.entity.DocumentField.Type;
 @SuppressWarnings({"WeakerAccess", "unused"})
 class CircleEdge {
 
-    @DocumentField(Type.ID)
+    @Id
     private String id;
 
-    @DocumentField(Type.KEY)
+    @Key
     private String key;
 
-    @DocumentField(Type.REV)
+    @Rev
     private String revision;
 
-    @DocumentField(Type.FROM)
+    @From
     private String from;
 
-    @DocumentField(Type.TO)
+    @To
     private String to;
 
     private Boolean theFalse;

--- a/src/test/java/com/arangodb/example/graph/Circle.java
+++ b/src/test/java/com/arangodb/example/graph/Circle.java
@@ -20,8 +20,9 @@
 
 package com.arangodb.example.graph;
 
-import com.arangodb.entity.DocumentField;
-import com.arangodb.entity.DocumentField.Type;
+import com.arangodb.entity.Id;
+import com.arangodb.entity.Key;
+import com.arangodb.entity.Rev;
 
 /**
  * @author a-brandt
@@ -29,13 +30,13 @@ import com.arangodb.entity.DocumentField.Type;
 @SuppressWarnings("unused")
 class Circle {
 
-    @DocumentField(Type.ID)
+    @Id
     private String id;
 
-    @DocumentField(Type.KEY)
+    @Key
     private String key;
 
-    @DocumentField(Type.REV)
+    @Rev
     private String revision;
 
     private String label;

--- a/src/test/java/com/arangodb/example/graph/CircleEdge.java
+++ b/src/test/java/com/arangodb/example/graph/CircleEdge.java
@@ -20,8 +20,7 @@
 
 package com.arangodb.example.graph;
 
-import com.arangodb.entity.DocumentField;
-import com.arangodb.entity.DocumentField.Type;
+import com.arangodb.entity.*;
 
 /**
  * @author a-brandt
@@ -29,19 +28,19 @@ import com.arangodb.entity.DocumentField.Type;
 @SuppressWarnings("unused")
 class CircleEdge {
 
-    @DocumentField(Type.ID)
+    @Id
     private String id;
 
-    @DocumentField(Type.KEY)
+    @Key
     private String key;
 
-    @DocumentField(Type.REV)
+    @Rev
     private String revision;
 
-    @DocumentField(Type.FROM)
+    @From
     private String from;
 
-    @DocumentField(Type.TO)
+    @To
     private String to;
 
     private Boolean theFalse;

--- a/src/test/java/com/arangodb/internal/DocumentCacheTest.java
+++ b/src/test/java/com/arangodb/internal/DocumentCacheTest.java
@@ -21,7 +21,6 @@
 package com.arangodb.internal;
 
 import com.arangodb.entity.BaseDocument;
-import com.arangodb.entity.DocumentField;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -44,10 +43,10 @@ class DocumentCacheTest {
         assertThat(doc.getKey()).isNull();
         assertThat(doc.getRevision()).isNull();
 
-        final Map<DocumentField.Type, String> values = new HashMap<>();
-        values.put(DocumentField.Type.ID, "testId");
-        values.put(DocumentField.Type.KEY, "testKey");
-        values.put(DocumentField.Type.REV, "testRev");
+        final Map<String, String> values = new HashMap<>();
+        values.put(DocumentFields.ID, "testId");
+        values.put(DocumentFields.KEY, "testKey");
+        values.put(DocumentFields.REV, "testRev");
         cache.setValues(doc, values);
 
         assertThat(doc.getId()).isEqualTo("testId");
@@ -60,10 +59,10 @@ class DocumentCacheTest {
         final DocumentCache cache = new DocumentCache();
         final Map<String, String> map = new HashMap<>();
 
-        final Map<DocumentField.Type, String> values = new HashMap<>();
-        values.put(DocumentField.Type.ID, "testId");
-        values.put(DocumentField.Type.KEY, "testKey");
-        values.put(DocumentField.Type.REV, "testRev");
+        final Map<String, String> values = new HashMap<>();
+        values.put(DocumentFields.ID, "testId");
+        values.put(DocumentFields.KEY, "testKey");
+        values.put(DocumentFields.REV, "testRev");
         cache.setValues(map, values);
 
         assertThat(map.isEmpty()).isTrue();

--- a/src/test/java/com/arangodb/mapping/annotations/AnnotatedEntity.java
+++ b/src/test/java/com/arangodb/mapping/annotations/AnnotatedEntity.java
@@ -1,0 +1,81 @@
+package com.arangodb.mapping.annotations;
+
+import com.arangodb.entity.*;
+
+import java.util.Objects;
+
+public class AnnotatedEntity {
+
+    @Id
+    private String id;
+
+    @Key
+    private String key;
+
+    @Rev
+    private String rev;
+
+    @From
+    private String from;
+
+    @To
+    private String to;
+
+    public AnnotatedEntity() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getRev() {
+        return rev;
+    }
+
+    public void setRev(String rev) {
+        this.rev = rev;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AnnotatedEntity that = (AnnotatedEntity) o;
+        return Objects.equals(getId(), that.getId()) && Objects.equals(getKey(), that.getKey()) && Objects
+                .equals(getRev(), that.getRev()) && Objects.equals(getFrom(), that.getFrom()) && Objects
+                .equals(getTo(), that.getTo());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getKey(), getRev(), getFrom(), getTo());
+    }
+}

--- a/src/test/java/com/arangodb/mapping/annotations/ArangoAnnotationsTest.java
+++ b/src/test/java/com/arangodb/mapping/annotations/ArangoAnnotationsTest.java
@@ -20,7 +20,6 @@
 
 package com.arangodb.mapping.annotations;
 
-import com.arangodb.entity.DocumentField;
 import com.arangodb.mapping.ArangoJack;
 import com.arangodb.velocypack.VPackSlice;
 import org.junit.jupiter.api.Test;
@@ -50,14 +49,38 @@ class ArangoAnnotationsTest {
         System.out.println(slice);
         Map<String, String> deserialized = mapper.deserialize(slice, Object.class);
         assertThat(deserialized)
-                .containsEntry(DocumentField.Type.ID.getSerializeName(), e.getId())
-                .containsEntry(DocumentField.Type.KEY.getSerializeName(), e.getKey())
-                .containsEntry(DocumentField.Type.REV.getSerializeName(), e.getRev())
-                .containsEntry(DocumentField.Type.FROM.getSerializeName(), e.getFrom())
-                .containsEntry(DocumentField.Type.TO.getSerializeName(), e.getTo())
-                .hasSize(DocumentField.Type.values().length);
+                .containsEntry("_id", e.getId())
+                .containsEntry("_key", e.getKey())
+                .containsEntry("_rev", e.getRev())
+                .containsEntry("_from", e.getFrom())
+                .containsEntry("_to", e.getTo())
+                .hasSize(5);
 
         DocumentFieldEntity deserializedEntity = mapper.deserialize(slice, DocumentFieldEntity.class);
+        assertThat(deserializedEntity).isEqualTo(e);
+    }
+
+    @Test
+    void documentFieldAnnotations() {
+        AnnotatedEntity e = new AnnotatedEntity();
+        e.setId("Id");
+        e.setKey("Key");
+        e.setRev("Rev");
+        e.setFrom("From");
+        e.setTo("To");
+
+        VPackSlice slice = mapper.serialize(e);
+        System.out.println(slice);
+        Map<String, String> deserialized = mapper.deserialize(slice, Object.class);
+        assertThat(deserialized)
+                .containsEntry("_id", e.getId())
+                .containsEntry("_key", e.getKey())
+                .containsEntry("_rev", e.getRev())
+                .containsEntry("_from", e.getFrom())
+                .containsEntry("_to", e.getTo())
+                .hasSize(5);
+
+        AnnotatedEntity deserializedEntity = mapper.deserialize(slice, AnnotatedEntity.class);
         assertThat(deserializedEntity).isEqualTo(e);
     }
 


### PR DESCRIPTION
This PR deprecates `DocumentField` annotation and introduces new alternative field annotations: `@Id`, `@Key`, `@Rev`, `@From`, `@To`, which are both compatible with VPack and Jackson serializers.