### PR TITLE
[DE-313] Allow specifying the return type in CRUD document operations

### DIFF
--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -372,7 +372,7 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#update-documents">API
      * Documentation</a>
      */
-    <T> MultiDocumentEntity<DocumentUpdateEntity<T>> updateDocuments(Collection<T> values) throws ArangoDBException;
+    MultiDocumentEntity<DocumentUpdateEntity<Void>> updateDocuments(Collection<?> values) throws ArangoDBException;
 
     /**
      * Partially updates documents, the documents to update are specified by the _key attributes in the objects on

--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -450,6 +450,20 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * Deletes multiple documents from the collection.
      *
      * @param values  The keys of the documents or the documents themselves
+     * @param options Additional options, can be null
+     * @return information about the documents
+     * @throws ArangoDBException
+     * @see <a href=
+     * "https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#removes-multiple-documents">API
+     * Documentation</a>
+     */
+    <T> MultiDocumentEntity<DocumentDeleteEntity<T>> deleteDocuments(
+            Collection<?> values, DocumentDeleteOptions options) throws ArangoDBException;
+
+    /**
+     * Deletes multiple documents from the collection.
+     *
+     * @param values  The keys of the documents or the documents themselves
      * @param type    The type of the documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes}). Only necessary if
      *                options.returnOld is set to true, otherwise can be null.
      * @param options Additional options, can be null
@@ -460,7 +474,7 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * Documentation</a>
      */
     <T> MultiDocumentEntity<DocumentDeleteEntity<T>> deleteDocuments(
-            Collection<?> values, Class<T> type, DocumentDeleteOptions options) throws ArangoDBException;
+            Collection<?> values, DocumentDeleteOptions options, Class<T> type) throws ArangoDBException;
 
     /**
      * Checks if the document exists by reading a single document head

--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -291,7 +291,7 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#update-document">API
      * Documentation</a>
      */
-    <T> DocumentUpdateEntity<T> updateDocument(String key, T value) throws ArangoDBException;
+    DocumentUpdateEntity<Void> updateDocument(String key, Object value) throws ArangoDBException;
 
     /**
      * Partially updates the document identified by document-key. The value must contain a document with the attributes

--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -61,7 +61,7 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
      * Documentation</a>
      */
-    <T> DocumentCreateEntity<T> insertDocument(T value) throws ArangoDBException;
+    DocumentCreateEntity<Void> insertDocument(Object value) throws ArangoDBException;
 
     /**
      * Creates a new document from the given document, unless there is already a document with the _key given. If no
@@ -75,6 +75,20 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * Documentation</a>
      */
     <T> DocumentCreateEntity<T> insertDocument(T value, DocumentCreateOptions options) throws ArangoDBException;
+
+    /**
+     * Creates a new document from the given document, unless there is already a document with the _key given. If no
+     * _key is given, a new unique _key is generated automatically.
+     *
+     * @param value   A representation of a single document (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
+     * @param options Additional options, can be null
+     * @param type  Deserialization target type for the returned documents.
+     * @return information about the document
+     * @throws ArangoDBException
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
+     * Documentation</a>
+     */
+    <T> DocumentCreateEntity<T> insertDocument(T value, DocumentCreateOptions options, Class<T> type) throws ArangoDBException;
 
     /**
      * Creates new documents from the given documents, unless there is already a document with the _key given. If no

--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -93,9 +93,6 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
     /**
      * Creates new documents from the given documents, unless there is already a document with the _key given. If no
      * _key is given, a new unique _key is generated automatically.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
      * @return information about the documents
@@ -108,9 +105,6 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
     /**
      * Creates new documents from the given documents, unless there is already a document with the _key given. If no
      * _key is given, a new unique _key is generated automatically.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values  A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
      * @param options Additional options, can be null
@@ -125,9 +119,6 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
     /**
      * Creates new documents from the given documents, unless there is already a document with the _key given. If no
      * _key is given, a new unique _key is generated automatically.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values  A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
      * @param options Additional options, can be null
@@ -142,9 +133,6 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
 
     /**
      * Bulk imports the given values into the collection.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values a list of Objects that will be stored as documents
      * @return information about the import
@@ -154,9 +142,6 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
 
     /**
      * Bulk imports the given values into the collection.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values  a list of Objects that will be stored as documents
      * @param options Additional options, can be null
@@ -167,9 +152,6 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
 
     /**
      * Bulk imports the given values into the collection.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values JSON-encoded array of objects that will be stored as documents
      * @return information about the import
@@ -179,9 +161,6 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
 
     /**
      * Bulk imports the given values into the collection.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values  JSON-encoded array of objects that will be stored as documents
      * @param options Additional options, can be null
@@ -284,9 +263,6 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
     /**
      * Replaces multiple documents in the specified collection with the ones in the values, the replaced documents are
      * specified by the _key attributes in the documents in values.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
      * @return information about the documents
@@ -294,14 +270,11 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#replace-documents">API
      * Documentation</a>
      */
-    <T> MultiDocumentEntity<DocumentUpdateEntity<T>> replaceDocuments(Collection<T> values) throws ArangoDBException;
+    MultiDocumentEntity<DocumentUpdateEntity<Void>> replaceDocuments(Collection<?> values) throws ArangoDBException;
 
     /**
      * Replaces multiple documents in the specified collection with the ones in the values, the replaced documents are
      * specified by the _key attributes in the documents in values.
-     * <p>
-     * Limitations:
-     * - the fields having {@code null} value are always removed during serialization
      *
      * @param values  A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
      * @param options Additional options, can be null
@@ -312,6 +285,21 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      */
     <T> MultiDocumentEntity<DocumentUpdateEntity<T>> replaceDocuments(
             Collection<T> values, DocumentReplaceOptions options) throws ArangoDBException;
+
+    /**
+     * Replaces multiple documents in the specified collection with the ones in the values, the replaced documents are
+     * specified by the _key attributes in the documents in values.
+     *
+     * @param values  A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
+     * @param options Additional options, can be null
+     * @param type  Deserialization target type for the returned documents.
+     * @return information about the documents
+     * @throws ArangoDBException
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#replace-documents">API
+     * Documentation</a>
+     */
+    <T> MultiDocumentEntity<DocumentUpdateEntity<T>> replaceDocuments(
+            Collection<T> values, DocumentReplaceOptions options, Class<T> type) throws ArangoDBException;
 
     /**
      * Partially updates the document identified by document-key. The value must contain a document with the attributes

--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -103,7 +103,7 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
      * Documentation</a>
      */
-    <T> MultiDocumentEntity<DocumentCreateEntity<T>> insertDocuments(Collection<T> values) throws ArangoDBException;
+    MultiDocumentEntity<DocumentCreateEntity<Void>> insertDocuments(Collection<?> values) throws ArangoDBException;
 
     /**
      * Creates new documents from the given documents, unless there is already a document with the _key given. If no
@@ -121,6 +121,24 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      */
     <T> MultiDocumentEntity<DocumentCreateEntity<T>> insertDocuments(
             Collection<T> values, DocumentCreateOptions options) throws ArangoDBException;
+
+    /**
+     * Creates new documents from the given documents, unless there is already a document with the _key given. If no
+     * _key is given, a new unique _key is generated automatically.
+     * <p>
+     * Limitations:
+     * - the fields having {@code null} value are always removed during serialization
+     *
+     * @param values  A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
+     * @param options Additional options, can be null
+     * @param type  Deserialization target type for the returned documents.
+     * @return information about the documents
+     * @throws ArangoDBException
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
+     * Documentation</a>
+     */
+    <T> MultiDocumentEntity<DocumentCreateEntity<T>> insertDocuments(
+            Collection<T> values, DocumentCreateOptions options, Class<T> type) throws ArangoDBException;
 
     /**
      * Bulk imports the given values into the collection.

--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -82,7 +82,7 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      *
      * @param value   A representation of a single document (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
      * @param options Additional options, can be null
-     * @param type  Deserialization target type for the returned documents.
+     * @param type    Deserialization target type for the returned documents.
      * @return information about the document
      * @throws ArangoDBException
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
@@ -230,7 +230,7 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#replace-document">API
      * Documentation</a>
      */
-    <T> DocumentUpdateEntity<T> replaceDocument(String key, T value) throws ArangoDBException;
+    DocumentUpdateEntity<Void> replaceDocument(String key, Object value) throws ArangoDBException;
 
     /**
      * Replaces the document with {@code key} with the one in the body, provided there is such a document and no
@@ -245,6 +245,22 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * Documentation</a>
      */
     <T> DocumentUpdateEntity<T> replaceDocument(String key, T value, DocumentReplaceOptions options)
+            throws ArangoDBException;
+
+    /**
+     * Replaces the document with {@code key} with the one in the body, provided there is such a document and no
+     * precondition is violated
+     *
+     * @param key     The key of the document
+     * @param value   A representation of a single document (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
+     * @param options Additional options, can be null
+     * @param type    Deserialization target type for the returned documents.
+     * @return information about the document
+     * @throws ArangoDBException
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#replace-document">API
+     * Documentation</a>
+     */
+    <T> DocumentUpdateEntity<T> replaceDocument(String key, T value, DocumentReplaceOptions options, Class<T> type)
             throws ArangoDBException;
 
     /**

--- a/src/main/java/com/arangodb/ArangoCollection.java
+++ b/src/main/java/com/arangodb/ArangoCollection.java
@@ -422,6 +422,19 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * Deletes the document with the given {@code key} from the collection.
      *
      * @param key     The key of the document
+     * @param options Additional options, can be null
+     * @return information about the document
+     * @throws ArangoDBException
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#removes-a-document">API
+     * Documentation</a>
+     */
+    <T> DocumentDeleteEntity<T> deleteDocument(String key, DocumentDeleteOptions options)
+            throws ArangoDBException;
+
+    /**
+     * Deletes the document with the given {@code key} from the collection.
+     *
+     * @param key     The key of the document
      * @param type    The type of the document (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes}). Only necessary if
      *                options.returnOld is set to true, otherwise can be null.
      * @param options Additional options, can be null
@@ -430,7 +443,7 @@ public interface ArangoCollection extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#removes-a-document">API
      * Documentation</a>
      */
-    <T> DocumentDeleteEntity<T> deleteDocument(String key, Class<T> type, DocumentDeleteOptions options)
+    <T> DocumentDeleteEntity<T> deleteDocument(String key, DocumentDeleteOptions options, Class<T> type)
             throws ArangoDBException;
 
     /**

--- a/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
@@ -448,6 +448,20 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * Removes multiple document
      *
      * @param values  The keys of the documents or the documents themselves
+     * @param options Additional options, can be null
+     * @return information about the documents
+     * @see <a href=
+     * "https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#removes-multiple-documents">API
+     * Documentation</a>
+     */
+    <T> CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<T>>> deleteDocuments(
+            final Collection<?> values,
+            final DocumentDeleteOptions options);
+
+    /**
+     * Removes multiple document
+     *
+     * @param values  The keys of the documents or the documents themselves
      * @param type    The type of the documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes}). Only necessary if
      *                options.returnOld is set to true, otherwise can be null.
      * @param options Additional options, can be null
@@ -458,8 +472,8 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      */
     <T> CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<T>>> deleteDocuments(
             final Collection<?> values,
-            final Class<T> type,
-            final DocumentDeleteOptions options);
+            final DocumentDeleteOptions options,
+            final Class<T> type);
 
     /**
      * Checks if the document exists by reading a single document head

--- a/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
@@ -392,6 +392,19 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * Removes a document
      *
      * @param key     The key of the document
+     * @param options Additional options, can be null
+     * @return information about the document
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#removes-a-document">API
+     * Documentation</a>
+     */
+    <T> CompletableFuture<DocumentDeleteEntity<T>> deleteDocument(
+            final String key,
+            final DocumentDeleteOptions options);
+
+    /**
+     * Removes a document
+     *
+     * @param key     The key of the document
      * @param type    The type of the document (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes}). Only necessary if
      *                options.returnOld is set to true, otherwise can be null.
      * @param options Additional options, can be null
@@ -401,8 +414,8 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      */
     <T> CompletableFuture<DocumentDeleteEntity<T>> deleteDocument(
             final String key,
-            final Class<T> type,
-            final DocumentDeleteOptions options);
+            final DocumentDeleteOptions options,
+            final Class<T> type);
 
     /**
      * Removes multiple document

--- a/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
@@ -342,7 +342,7 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#update-documents">API
      * Documentation</a>
      */
-    <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> updateDocuments(final Collection<T> values);
+    CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<Void>>> updateDocuments(final Collection<?> values);
 
     /**
      * Partially updates documents, the documents to update are specified by the _key attributes in the objects on

--- a/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
@@ -259,7 +259,7 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#update-document">API
      * Documentation</a>
      */
-    <T> CompletableFuture<DocumentUpdateEntity<T>> updateDocument(final String key, final T value);
+    CompletableFuture<DocumentUpdateEntity<Void>> updateDocument(final String key, final Object value);
 
     /**
      * Partially updates the document identified by document-key. The value must contain a document with the attributes

--- a/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
@@ -61,7 +61,7 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
      * Documentation</a>
      */
-    <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(final T value);
+    CompletableFuture<DocumentCreateEntity<Void>> insertDocument(final Object value);
 
     /**
      * Creates a new document from the given document, unless there is already a document with the _key given. If no
@@ -74,6 +74,19 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * Documentation</a>
      */
     <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(final T value, final DocumentCreateOptions options);
+
+    /**
+     * Creates a new document from the given document, unless there is already a document with the _key given. If no
+     * _key is given, a new unique _key is generated automatically.
+     *
+     * @param value   A representation of a single document (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
+     * @param options Additional options, can be null
+     * @param type  Deserialization target type for the returned documents.
+     * @return information about the document
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
+     * Documentation</a>
+     */
+    <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(final T value, final DocumentCreateOptions options, Class<T> type);
 
     /**
      * Creates new documents from the given documents, unless there is already a document with the _key given. If no

--- a/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
@@ -205,7 +205,7 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#replace-document">API
      * Documentation</a>
      */
-    <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(final String key, final T value);
+    CompletableFuture<DocumentUpdateEntity<Void>> replaceDocument(final String key, final Object value);
 
     /**
      * Replaces the document with key with the one in the body, provided there is such a document and no precondition is
@@ -222,6 +222,24 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
             final String key,
             final T value,
             final DocumentReplaceOptions options);
+
+    /**
+     * Replaces the document with key with the one in the body, provided there is such a document and no precondition is
+     * violated
+     *
+     * @param key     The key of the document
+     * @param value   A representation of a single document (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
+     * @param options Additional options, can be null
+     * @param type  Deserialization target type for the returned documents.
+     * @return information about the document
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#replace-document">API
+     * Documentation</a>
+     */
+    <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(
+            final String key,
+            final T value,
+            final DocumentReplaceOptions options,
+            final Class<T> type);
 
     /**
      * Replaces multiple documents in the specified collection with the ones in the values, the replaced documents are

--- a/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
@@ -97,7 +97,7 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
      * Documentation</a>
      */
-    <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(final Collection<T> values);
+    CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<Void>>> insertDocuments(final Collection<?> values);
 
     /**
      * Creates new documents from the given documents, unless there is already a document with the _key given. If no
@@ -112,6 +112,22 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
     <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(
             final Collection<T> values,
             final DocumentCreateOptions options);
+
+    /**
+     * Creates new documents from the given documents, unless there is already a document with the _key given. If no
+     * _key is given, a new unique _key is generated automatically.
+     *
+     * @param values  A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
+     * @param options Additional options, can be null
+     * @param type  Deserialization target type for the returned documents.
+     * @return information about the documents
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#create-document">API
+     * Documentation</a>
+     */
+    <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(
+            final Collection<T> values,
+            final DocumentCreateOptions options,
+            final Class<T> type);
 
     /**
      * Imports documents

--- a/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/async/ArangoCollectionAsync.java
@@ -266,7 +266,7 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
      * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#replace-documents">API
      * Documentation</a>
      */
-    <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(final Collection<T> values);
+    CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<Void>>> replaceDocuments(final Collection<?> values);
 
     /**
      * Replaces multiple documents in the specified collection with the ones in the values, the replaced documents are
@@ -281,6 +281,22 @@ public interface ArangoCollectionAsync extends ArangoSerdeAccessor {
     <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(
             final Collection<T> values,
             final DocumentReplaceOptions options);
+
+    /**
+     * Replaces multiple documents in the specified collection with the ones in the values, the replaced documents are
+     * specified by the _key attributes in the documents in values.
+     *
+     * @param values  A List of documents (POJO, {@link com.arangodb.util.RawJson} or {@link com.arangodb.util.RawBytes})
+     * @param options Additional options, can be null
+     * @param type  Deserialization target type for the returned documents.
+     * @return information about the documents
+     * @see <a href="https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#replace-documents">API
+     * Documentation</a>
+     */
+    <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(
+            final Collection<T> values,
+            final DocumentReplaceOptions options,
+            final Class<T> type);
 
     /**
      * Partially updates the document identified by document-key. The value must contain a document with the attributes

--- a/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
@@ -253,15 +253,20 @@ public class ArangoCollectionAsyncImpl
     @Override
     public CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<Void>>> deleteDocuments(
             final Collection<?> values) {
-        return executor.execute(deleteDocumentsRequest(values, new DocumentDeleteOptions()),
-                deleteDocumentsResponseDeserializer(Void.class));
+        return deleteDocuments(values, new DocumentDeleteOptions(), Void.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<T>>> deleteDocuments(Collection<?> values, DocumentDeleteOptions options) {
+        return deleteDocuments(values, options, (Class<T>) getCollectionContentClass(values));
     }
 
     @Override
     public <T> CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<T>>> deleteDocuments(
             final Collection<?> values,
-            final Class<T> type,
-            final DocumentDeleteOptions options) {
+            final DocumentDeleteOptions options,
+            final Class<T> type) {
         return executor.execute(deleteDocumentsRequest(values, options), deleteDocumentsResponseDeserializer(type));
     }
 

--- a/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
@@ -66,20 +66,24 @@ public class ArangoCollectionAsyncImpl
     }
 
     @Override
-    public <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(
-            final Collection<T> values) {
-        final DocumentCreateOptions params = new DocumentCreateOptions();
-        return executor.execute(insertDocumentsRequest(values, params),
-                insertDocumentsResponseDeserializer(values, params));
+    public CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<Void>>> insertDocuments(
+            final Collection<?> values) {
+        return executor
+                .execute(insertDocumentsRequest(values, new DocumentCreateOptions()), insertDocumentsResponseDeserializer(Void.class));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(
             final Collection<T> values,
             final DocumentCreateOptions options) {
-        final DocumentCreateOptions params = (options != null ? options : new DocumentCreateOptions());
-        return executor.execute(insertDocumentsRequest(values, params),
-                insertDocumentsResponseDeserializer(values, params));
+        return insertDocuments(values, options, (Class<T>) getCollectionContentClass(values));
+    }
+
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(Collection<T> values, DocumentCreateOptions options, Class<T> type) {
+        return executor
+                .execute(insertDocumentsRequest(values, options), insertDocumentsResponseDeserializer(type));
     }
 
     @Override

--- a/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
@@ -172,8 +172,8 @@ public class ArangoCollectionAsyncImpl
     }
 
     @Override
-    public <T> CompletableFuture<DocumentUpdateEntity<T>> updateDocument(final String key, final T value) {
-        return updateDocument(key, value, new DocumentUpdateOptions());
+    public CompletableFuture<DocumentUpdateEntity<Void>> updateDocument(final String key, final Object value) {
+        return updateDocument(key, value, new DocumentUpdateOptions(), Void.class);
     }
 
     @Override

--- a/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
@@ -165,20 +165,22 @@ public class ArangoCollectionAsyncImpl
     }
 
     @Override
-    public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(
-            final Collection<T> values) {
-        final DocumentReplaceOptions params = new DocumentReplaceOptions();
-        return executor.execute(replaceDocumentsRequest(values, params),
-                replaceDocumentsResponseDeserializer(values));
+    public CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<Void>>> replaceDocuments(
+            final Collection<?> values) {
+        return executor.execute(replaceDocumentsRequest(values, new DocumentReplaceOptions()), replaceDocumentsResponseDeserializer(Void.class));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(
             final Collection<T> values,
             final DocumentReplaceOptions options) {
-        final DocumentReplaceOptions params = (options != null ? options : new DocumentReplaceOptions());
-        return executor.execute(replaceDocumentsRequest(values, params),
-                replaceDocumentsResponseDeserializer(values));
+        return replaceDocuments(values, options, (Class<T>) getCollectionContentClass(values));
+    }
+
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(Collection<T> values, DocumentReplaceOptions options, Class<T> type) {
+        return executor.execute(replaceDocumentsRequest(values, options), replaceDocumentsResponseDeserializer(type));
     }
 
     @Override

--- a/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
@@ -139,19 +139,25 @@ public class ArangoCollectionAsyncImpl
     }
 
     @Override
-    public <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(final String key, final T value) {
+    public CompletableFuture<DocumentUpdateEntity<Void>> replaceDocument(final String key, final Object value) {
         final DocumentReplaceOptions options = new DocumentReplaceOptions();
         return executor.execute(replaceDocumentRequest(key, value, options),
-                constructParametricType(DocumentUpdateEntity.class, value.getClass()));
+                constructParametricType(DocumentUpdateEntity.class, Void.class));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(
             final String key,
             final T value,
             final DocumentReplaceOptions options) {
+        return replaceDocument(key, value, options, (Class<T>) value.getClass());
+    }
+
+    @Override
+    public <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(String key, T value, DocumentReplaceOptions options, Class<T> type) {
         return executor.execute(replaceDocumentRequest(key, value, options),
-                constructParametricType(DocumentUpdateEntity.class, value.getClass()));
+                constructParametricType(DocumentUpdateEntity.class, type));
     }
 
     @Override

--- a/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
@@ -206,9 +206,9 @@ public class ArangoCollectionAsyncImpl
     }
 
     @Override
-    public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> updateDocuments(
-            final Collection<T> values) {
-        return updateDocuments(values, new DocumentUpdateOptions());
+    public CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<Void>>> updateDocuments(
+            final Collection<?> values) {
+        return updateDocuments(values, new DocumentUpdateOptions(), Void.class);
     }
 
     @Override
@@ -216,7 +216,7 @@ public class ArangoCollectionAsyncImpl
     public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> updateDocuments(
             final Collection<T> values,
             final DocumentUpdateOptions options) {
-        return updateDocuments(values, options, values.isEmpty() ? null : (Class<T>) getCollectionContentClass(values));
+        return updateDocuments(values, options, (Class<T>) getCollectionContentClass(values));
     }
 
     @Override
@@ -224,9 +224,8 @@ public class ArangoCollectionAsyncImpl
             final Collection<T> values,
             final DocumentUpdateOptions options,
             final Class<U> returnType) {
-        final DocumentUpdateOptions params = (options != null ? options : new DocumentUpdateOptions());
-        return executor.execute(updateDocumentsRequest(values, params),
-                updateDocumentsResponseDeserializer(returnType));
+        return executor
+                .execute(updateDocumentsRequest(values, options), updateDocumentsResponseDeserializer(returnType));
     }
 
     @Override

--- a/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
@@ -46,18 +46,23 @@ public class ArangoCollectionAsyncImpl
     }
 
     @Override
-    public <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(final T value) {
-        final DocumentCreateOptions options = new DocumentCreateOptions();
-        return executor.execute(insertDocumentRequest(value, options),
-                constructParametricType(DocumentCreateEntity.class, value.getClass()));
+    public CompletableFuture<DocumentCreateEntity<Void>> insertDocument(final Object value) {
+        return executor.execute(insertDocumentRequest(value, new DocumentCreateOptions()),
+                constructParametricType(DocumentCreateEntity.class, Void.class));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(
             final T value,
             final DocumentCreateOptions options) {
+        return insertDocument(value, options, (Class<T>) value.getClass());
+    }
+
+    @Override
+    public <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(T value, DocumentCreateOptions options, Class<T> type) {
         return executor.execute(insertDocumentRequest(value, options),
-                constructParametricType(DocumentCreateEntity.class, value.getClass()));
+                constructParametricType(DocumentCreateEntity.class, type));
     }
 
     @Override

--- a/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/async/internal/ArangoCollectionAsyncImpl.java
@@ -231,15 +231,20 @@ public class ArangoCollectionAsyncImpl
 
     @Override
     public CompletableFuture<DocumentDeleteEntity<Void>> deleteDocument(final String key) {
-        return executor.execute(deleteDocumentRequest(key, new DocumentDeleteOptions()),
-                constructParametricType(DocumentDeleteEntity.class, Void.class));
+        return deleteDocument(key, new DocumentDeleteOptions());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> CompletableFuture<DocumentDeleteEntity<T>> deleteDocument(String key, DocumentDeleteOptions options) {
+        return deleteDocument(key, options, (Class<T>) Void.class);
     }
 
     @Override
     public <T> CompletableFuture<DocumentDeleteEntity<T>> deleteDocument(
             final String key,
-            final Class<T> type,
-            final DocumentDeleteOptions options) {
+            final DocumentDeleteOptions options,
+            final Class<T> type) {
         return executor.execute(deleteDocumentRequest(key, options),
                 constructParametricType(DocumentDeleteEntity.class, type));
     }

--- a/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
@@ -25,7 +25,6 @@ import com.arangodb.ArangoDBException;
 import com.arangodb.entity.*;
 import com.arangodb.internal.util.DocumentUtil;
 import com.arangodb.model.*;
-import com.arangodb.serde.SerdeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,15 +143,22 @@ public class ArangoCollectionImpl extends InternalArangoCollection<ArangoDBImpl,
     }
 
     @Override
-    public <T> DocumentUpdateEntity<T> replaceDocument(final String key, final T value) throws ArangoDBException {
-        return replaceDocument(key, value, new DocumentReplaceOptions());
+    public DocumentUpdateEntity<Void> replaceDocument(final String key, final Object value) throws ArangoDBException {
+        return executor.execute(replaceDocumentRequest(key, value, new DocumentReplaceOptions()),
+                constructParametricType(DocumentUpdateEntity.class, Void.class));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> DocumentUpdateEntity<T> replaceDocument(
             final String key, final T value, final DocumentReplaceOptions options) throws ArangoDBException {
+        return replaceDocument(key, value, options, (Class<T>) value.getClass());
+    }
+
+    @Override
+    public <T> DocumentUpdateEntity<T> replaceDocument(String key, T value, DocumentReplaceOptions options, Class<T> type) throws ArangoDBException {
         return executor.execute(replaceDocumentRequest(key, value, options),
-                constructParametricType(DocumentUpdateEntity.class, value.getClass()));
+                constructParametricType(DocumentUpdateEntity.class, type));
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
@@ -47,15 +47,22 @@ public class ArangoCollectionImpl extends InternalArangoCollection<ArangoDBImpl,
     }
 
     @Override
-    public <T> DocumentCreateEntity<T> insertDocument(final T value) throws ArangoDBException {
-        return insertDocument(value, new DocumentCreateOptions());
+    public DocumentCreateEntity<Void> insertDocument(final Object value) throws ArangoDBException {
+        return executor.execute(insertDocumentRequest(value, new DocumentCreateOptions()),
+                constructParametricType(DocumentCreateEntity.class, Void.class));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> DocumentCreateEntity<T> insertDocument(final T value, final DocumentCreateOptions options)
             throws ArangoDBException {
+        return insertDocument(value, options, (Class<T>) value.getClass());
+    }
+
+    @Override
+    public <T> DocumentCreateEntity<T> insertDocument(final T value, final DocumentCreateOptions options, final Class<T> type) throws ArangoDBException {
         return executor.execute(insertDocumentRequest(value, options),
-                constructParametricType(DocumentCreateEntity.class, value.getClass()));
+                constructParametricType(DocumentCreateEntity.class, type));
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
@@ -223,13 +223,18 @@ public class ArangoCollectionImpl extends InternalArangoCollection<ArangoDBImpl,
 
     @Override
     public DocumentDeleteEntity<Void> deleteDocument(final String key) throws ArangoDBException {
-        return executor.execute(deleteDocumentRequest(key, new DocumentDeleteOptions()),
-                constructParametricType(DocumentDeleteEntity.class, Void.class));
+        return deleteDocument(key, new DocumentDeleteOptions());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> DocumentDeleteEntity<T> deleteDocument(String key, DocumentDeleteOptions options) throws ArangoDBException {
+        return deleteDocument(key, options, (Class<T>) Void.class);
     }
 
     @Override
     public <T> DocumentDeleteEntity<T> deleteDocument(
-            final String key, final Class<T> type, final DocumentDeleteOptions options) throws ArangoDBException {
+            final String key, final DocumentDeleteOptions options, final Class<T> type) throws ArangoDBException {
         return executor.execute(deleteDocumentRequest(key, options),
                 constructParametricType(DocumentDeleteEntity.class, type));
     }

--- a/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
@@ -245,13 +245,20 @@ public class ArangoCollectionImpl extends InternalArangoCollection<ArangoDBImpl,
     @Override
     public MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteDocuments(final Collection<?> values)
             throws ArangoDBException {
-        return executor.execute(deleteDocumentsRequest(values, new DocumentDeleteOptions()),
-                deleteDocumentsResponseDeserializer(Void.class));
+        return deleteDocuments(values, new DocumentDeleteOptions(), Void.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> MultiDocumentEntity<DocumentDeleteEntity<T>> deleteDocuments(
+            final Collection<?> values, final DocumentDeleteOptions options)
+            throws ArangoDBException {
+        return deleteDocuments(values, options, (Class<T>) getCollectionContentClass(values));
     }
 
     @Override
     public <T> MultiDocumentEntity<DocumentDeleteEntity<T>> deleteDocuments(
-            final Collection<?> values, final Class<T> type, final DocumentDeleteOptions options)
+            final Collection<?> values, final DocumentDeleteOptions options, final Class<T> type)
             throws ArangoDBException {
         return executor.execute(deleteDocumentsRequest(values, options), deleteDocumentsResponseDeserializer(type));
     }

--- a/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
@@ -170,8 +170,8 @@ public class ArangoCollectionImpl extends InternalArangoCollection<ArangoDBImpl,
     }
 
     @Override
-    public <T> DocumentUpdateEntity<T> updateDocument(final String key, final T value) throws ArangoDBException {
-        return updateDocument(key, value, new DocumentUpdateOptions());
+    public DocumentUpdateEntity<Void> updateDocument(final String key, final Object value) throws ArangoDBException {
+        return updateDocument(key, value, new DocumentUpdateOptions(), Void.class);
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
@@ -168,17 +168,21 @@ public class ArangoCollectionImpl extends InternalArangoCollection<ArangoDBImpl,
     }
 
     @Override
-    public <T> MultiDocumentEntity<DocumentUpdateEntity<T>> replaceDocuments(final Collection<T> values)
+    public MultiDocumentEntity<DocumentUpdateEntity<Void>> replaceDocuments(final Collection<?> values)
             throws ArangoDBException {
-        return replaceDocuments(values, new DocumentReplaceOptions());
+        return executor.execute(replaceDocumentsRequest(values, new DocumentReplaceOptions()), replaceDocumentsResponseDeserializer(Void.class));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> MultiDocumentEntity<DocumentUpdateEntity<T>> replaceDocuments(
             final Collection<T> values, final DocumentReplaceOptions options) throws ArangoDBException {
-        final DocumentReplaceOptions params = (options != null ? options : new DocumentReplaceOptions());
-        return executor
-                .execute(replaceDocumentsRequest(values, params), replaceDocumentsResponseDeserializer(values));
+        return replaceDocuments(values, options, (Class<T>) getCollectionContentClass(values));
+    }
+
+    @Override
+    public <T> MultiDocumentEntity<DocumentUpdateEntity<T>> replaceDocuments(Collection<T> values, DocumentReplaceOptions options, Class<T> type) throws ArangoDBException {
+        return executor.execute(replaceDocumentsRequest(values, options), replaceDocumentsResponseDeserializer(type));
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
@@ -65,17 +65,23 @@ public class ArangoCollectionImpl extends InternalArangoCollection<ArangoDBImpl,
     }
 
     @Override
-    public <T> MultiDocumentEntity<DocumentCreateEntity<T>> insertDocuments(final Collection<T> values)
+    public MultiDocumentEntity<DocumentCreateEntity<Void>> insertDocuments(final Collection<?> values)
             throws ArangoDBException {
-        return insertDocuments(values, new DocumentCreateOptions());
+        return executor
+                .execute(insertDocumentsRequest(values, new DocumentCreateOptions()), insertDocumentsResponseDeserializer(Void.class));
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> MultiDocumentEntity<DocumentCreateEntity<T>> insertDocuments(
             final Collection<T> values, final DocumentCreateOptions options) throws ArangoDBException {
-        final DocumentCreateOptions params = (options != null ? options : new DocumentCreateOptions());
+        return insertDocuments(values, options, (Class<T>) getCollectionContentClass(values));
+    }
+
+    @Override
+    public <T> MultiDocumentEntity<DocumentCreateEntity<T>> insertDocuments(Collection<T> values, DocumentCreateOptions options, Class<T> type) throws ArangoDBException {
         return executor
-                .execute(insertDocumentsRequest(values, params), insertDocumentsResponseDeserializer(values, params));
+                .execute(insertDocumentsRequest(values, options), insertDocumentsResponseDeserializer(type));
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionImpl.java
@@ -201,24 +201,23 @@ public class ArangoCollectionImpl extends InternalArangoCollection<ArangoDBImpl,
     }
 
     @Override
-    public <T> MultiDocumentEntity<DocumentUpdateEntity<T>> updateDocuments(final Collection<T> values)
+    public MultiDocumentEntity<DocumentUpdateEntity<Void>> updateDocuments(final Collection<?> values)
             throws ArangoDBException {
-        return updateDocuments(values, new DocumentUpdateOptions());
+        return updateDocuments(values, new DocumentUpdateOptions(), Void.class);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T> MultiDocumentEntity<DocumentUpdateEntity<T>> updateDocuments(
             final Collection<T> values, final DocumentUpdateOptions options) throws ArangoDBException {
-        return updateDocuments(values, options, values.isEmpty() ? null : (Class<T>) getCollectionContentClass(values));
+        return updateDocuments(values, options, (Class<T>) getCollectionContentClass(values));
     }
 
     @Override
     public <T, U> MultiDocumentEntity<DocumentUpdateEntity<U>> updateDocuments(
             final Collection<T> values, final DocumentUpdateOptions options, final Class<U> returnType) throws ArangoDBException {
-        final DocumentUpdateOptions params = (options != null ? options : new DocumentUpdateOptions());
         return executor
-                .execute(updateDocumentsRequest(values, params), updateDocumentsResponseDeserializer(returnType));
+                .execute(updateDocumentsRequest(values, options), updateDocumentsResponseDeserializer(returnType));
     }
 
     @Override

--- a/src/main/java/com/arangodb/internal/InternalArangoCollection.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoCollection.java
@@ -241,9 +241,8 @@ public abstract class InternalArangoCollection<A extends InternalArangoDB<E>, D 
     }
 
     protected <T> ResponseDeserializer<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocumentsResponseDeserializer(
-            final Collection<T> values) {
+            final Class<T> returnType) {
         return response -> {
-            Class<?> userDataClass = getCollectionContentClass(values);
             final MultiDocumentEntity<DocumentUpdateEntity<T>> multiDocument = new MultiDocumentEntity<>();
             final Collection<DocumentUpdateEntity<T>> docs = new ArrayList<>();
             final Collection<ErrorEntity> errors = new ArrayList<>();
@@ -256,7 +255,7 @@ public abstract class InternalArangoCollection<A extends InternalArangoDB<E>, D 
                     errors.add(error);
                     documentsAndErrors.add(error);
                 } else {
-                    Type type = constructParametricType(DocumentUpdateEntity.class, userDataClass);
+                    Type type = constructParametricType(DocumentUpdateEntity.class, returnType);
                     final DocumentUpdateEntity<T> doc = getSerde().deserialize(next, type);
                     docs.add(doc);
                     documentsAndErrors.add(doc);

--- a/src/main/java/com/arangodb/internal/InternalArangoCollection.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoCollection.java
@@ -109,10 +109,8 @@ public abstract class InternalArangoCollection<A extends InternalArangoDB<E>, D 
         return request;
     }
 
-    protected <T> ResponseDeserializer<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocumentsResponseDeserializer(
-            final Collection<T> values, final DocumentCreateOptions params) {
+    protected <T> ResponseDeserializer<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocumentsResponseDeserializer(Class<T> userDataClass) {
         return response -> {
-            Class<?> userDataClass = getCollectionContentClass(values);
             final MultiDocumentEntity<DocumentCreateEntity<T>> multiDocument = new MultiDocumentEntity<>();
             final Collection<DocumentCreateEntity<T>> docs = new ArrayList<>();
             final Collection<ErrorEntity> errors = new ArrayList<>();

--- a/src/main/java/com/arangodb/model/DocumentCreateOptions.java
+++ b/src/main/java/com/arangodb/model/DocumentCreateOptions.java
@@ -86,11 +86,6 @@ public final class DocumentCreateOptions {
     }
 
     /**
-     * Limitations:
-     * - {@code keepNull} parameter is not supported
-     * - the fields having {@code null} value are always removed during serialization
-     * Therefore in case of {@link OverwriteMode#update}, existing attributes cannot be removed.
-     *
      * @param overwriteMode This parameter can be set to replace or update. If given it sets implicitly the overwrite
      *                      flag. In case it is set to update, the replace-insert becomes an update-insert. Otherwise
      *                      this option follows the rules of the overwrite parameter.

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -821,7 +821,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         final DocumentCreateEntity<?> createResult = collection.insertDocument(doc);
         final TestUpdateEntity patchDoc = new TestUpdateEntity();
         patchDoc.a = "bar";
-        final DocumentUpdateEntity<TestUpdateEntity> updateResult = collection.updateDocument(createResult.getKey(), patchDoc);
+        final DocumentUpdateEntity<?> updateResult = collection.updateDocument(createResult.getKey(), patchDoc);
         assertThat(updateResult).isNotNull();
         assertThat(updateResult.getKey()).isEqualTo(createResult.getKey());
 
@@ -840,7 +840,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         final DocumentCreateEntity<?> createResult = collection.insertDocument(doc);
         final TestUpdateEntitySerializeNullFalse patchDoc = new TestUpdateEntitySerializeNullFalse();
         patchDoc.a = "bar";
-        final DocumentUpdateEntity<TestUpdateEntitySerializeNullFalse> updateResult = collection.updateDocument(createResult.getKey(), patchDoc);
+        final DocumentUpdateEntity<?> updateResult = collection.updateDocument(createResult.getKey(), patchDoc);
         assertThat(updateResult).isNotNull();
         assertThat(updateResult.getKey()).isEqualTo(createResult.getKey());
 

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -1208,7 +1208,10 @@ class ArangoCollectionTest extends BaseJunit5 {
     void deleteDocumentsSilent(ArangoCollection collection) {
         assumeTrue(isSingleServer());
         final DocumentCreateEntity<?> createResult = collection.insertDocument(new BaseDocument());
-        final MultiDocumentEntity<DocumentDeleteEntity<BaseDocument>> info = collection.deleteDocuments(Collections.singletonList(createResult.getKey()), BaseDocument.class, new DocumentDeleteOptions().silent(true));
+        final MultiDocumentEntity<DocumentDeleteEntity<BaseDocument>> info = collection.deleteDocuments(
+                Collections.singletonList(createResult.getKey()),
+                new DocumentDeleteOptions().silent(true),
+                BaseDocument.class);
         assertThat(info).isNotNull();
         assertThat(info.getDocuments()).isEmpty();
         assertThat(info.getDocumentsAndErrors()).isEmpty();
@@ -2344,10 +2347,10 @@ class ArangoCollectionTest extends BaseJunit5 {
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
         keys.add("2");
-        final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(keys, null, null);
+        final MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteResult = collection.deleteDocuments(keys);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).hasSize(2);
-        for (final DocumentDeleteEntity<Object> i : deleteResult.getDocuments()) {
+        for (final DocumentDeleteEntity<Void> i : deleteResult.getDocuments()) {
             assertThat(i.getKey()).isIn("1", "2");
         }
         assertThat(deleteResult.getErrors()).isEmpty();
@@ -2368,10 +2371,10 @@ class ArangoCollectionTest extends BaseJunit5 {
             values.add(e);
         }
         collection.insertDocuments(values);
-        final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(values, null, null);
+        MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteResult = collection.deleteDocuments(values);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).hasSize(2);
-        for (final DocumentDeleteEntity<Object> i : deleteResult.getDocuments()) {
+        for (final DocumentDeleteEntity<Void> i : deleteResult.getDocuments()) {
             assertThat(i.getKey()).isIn("1", "2");
         }
         assertThat(deleteResult.getErrors()).isEmpty();
@@ -2389,10 +2392,10 @@ class ArangoCollectionTest extends BaseJunit5 {
         collection.insertDocuments(values);
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
-        final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(keys, null, null);
+        final MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteResult = collection.deleteDocuments(keys);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).hasSize(1);
-        for (final DocumentDeleteEntity<Object> i : deleteResult.getDocuments()) {
+        for (final DocumentDeleteEntity<Void> i : deleteResult.getDocuments()) {
             assertThat(i.getKey()).isEqualTo("1");
         }
         assertThat(deleteResult.getErrors()).isEmpty();
@@ -2408,10 +2411,10 @@ class ArangoCollectionTest extends BaseJunit5 {
             values.add(e);
         }
         collection.insertDocuments(values);
-        final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(values, null, null);
+        final MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteResult = collection.deleteDocuments(values);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).hasSize(1);
-        for (final DocumentDeleteEntity<Object> i : deleteResult.getDocuments()) {
+        for (final DocumentDeleteEntity<Void> i : deleteResult.getDocuments()) {
             assertThat(i.getKey()).isEqualTo("1");
         }
         assertThat(deleteResult.getErrors()).isEmpty();
@@ -2423,7 +2426,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         final Collection<BaseDocument> values = new ArrayList<>();
         collection.insertDocuments(values);
         final Collection<String> keys = new ArrayList<>();
-        final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(keys, null, null);
+        final MultiDocumentEntity<?> deleteResult = collection.deleteDocuments(keys);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).isEmpty();
         assertThat(deleteResult.getErrors()).isEmpty();
@@ -2436,7 +2439,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         collection.insertDocuments(values);
         final Collection<String> keys = Arrays.asList(rnd(), rnd());
 
-        final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(keys, null, null);
+        final MultiDocumentEntity<?> deleteResult = collection.deleteDocuments(keys);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).isEmpty();
         assertThat(deleteResult.getErrors()).hasSize(2);
@@ -2456,7 +2459,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             e.setKey("2");
             values.add(e);
         }
-        final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(values, null, null);
+        final MultiDocumentEntity<?> deleteResult = collection.deleteDocuments(values);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).isEmpty();
         assertThat(deleteResult.getErrors()).hasSize(2);

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -2573,7 +2573,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             i.addAttribute("a", "test");
             updatedValues.add(i);
         }
-        final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.replaceDocuments(updatedValues, null);
+        final MultiDocumentEntity<?> updateResult = collection.replaceDocuments(updatedValues);
         assertThat(updateResult.getDocuments()).hasSize(2);
         assertThat(updateResult.getErrors()).isEmpty();
     }
@@ -2636,7 +2636,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         final Collection<RawJson> updatedValues = new ArrayList<>();
         updatedValues.add(RawJson.of("{\"_key\":\"1\", \"foo\":\"bar\"}"));
         updatedValues.add(RawJson.of("{\"_key\":\"2\", \"foo\":\"bar\"}"));
-        final MultiDocumentEntity<DocumentUpdateEntity<RawJson>> updateResult = collection.replaceDocuments(updatedValues);
+        final MultiDocumentEntity<?> updateResult = collection.replaceDocuments(updatedValues);
         assertThat(updateResult.getDocuments()).hasSize(2);
         assertThat(updateResult.getErrors()).isEmpty();
     }

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -558,7 +558,7 @@ class ArangoCollectionTest extends BaseJunit5 {
 
         List<BaseDocument> values = IntStream.range(0, 10).mapToObj(String::valueOf).map(key -> new BaseDocument()).peek(it -> it.addAttribute("customField", rnd())).collect(Collectors.toList());
 
-        MultiDocumentEntity<DocumentCreateEntity<BaseDocument>> inserted = collection.insertDocuments(values);
+        MultiDocumentEntity<DocumentCreateEntity<Void>> inserted = collection.insertDocuments(values);
         List<String> insertedKeys = inserted.getDocuments().stream().map(DocumentEntity::getKey).collect(Collectors.toList());
 
         final Collection<BaseDocument> documents = collection.getDocuments(insertedKeys, BaseDocument.class).getDocuments();
@@ -1834,7 +1834,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     void insertDocuments(ArangoCollection collection) {
         final Collection<BaseDocument> values = Arrays.asList(new BaseDocument(), new BaseDocument(), new BaseDocument());
 
-        final MultiDocumentEntity<DocumentCreateEntity<BaseDocument>> docs = collection.insertDocuments(values, null);
+        final MultiDocumentEntity<?> docs = collection.insertDocuments(values);
         assertThat(docs).isNotNull();
         assertThat(docs.getDocuments()).isNotNull();
         assertThat(docs.getDocuments()).hasSize(3);
@@ -1877,7 +1877,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         values.add(RawJson.of("{}"));
         values.add(RawJson.of("{}"));
         values.add(RawJson.of("{}"));
-        final MultiDocumentEntity<DocumentCreateEntity<RawJson>> docs = collection.insertDocuments(values);
+        final MultiDocumentEntity<?> docs = collection.insertDocuments(values);
         assertThat(docs).isNotNull();
         assertThat(docs.getDocuments()).isNotNull();
         assertThat(docs.getDocuments()).hasSize(3);
@@ -1890,7 +1890,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     void insertDocumentsOne(ArangoCollection collection) {
         final Collection<BaseDocument> values = new ArrayList<>();
         values.add(new BaseDocument());
-        final MultiDocumentEntity<DocumentCreateEntity<BaseDocument>> docs = collection.insertDocuments(values, null);
+        final MultiDocumentEntity<?> docs = collection.insertDocuments(values);
         assertThat(docs).isNotNull();
         assertThat(docs.getDocuments()).isNotNull();
         assertThat(docs.getDocuments()).hasSize(1);
@@ -1902,7 +1902,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     @MethodSource("cols")
     void insertDocumentsEmpty(ArangoCollection collection) {
         final Collection<BaseDocument> values = new ArrayList<>();
-        final MultiDocumentEntity<DocumentCreateEntity<BaseDocument>> docs = collection.insertDocuments(values, null);
+        final MultiDocumentEntity<?> docs = collection.insertDocuments(values);
         assertThat(docs).isNotNull();
         assertThat(docs.getDocuments()).isNotNull();
         assertThat(docs.getDocuments()).isEmpty();
@@ -1939,7 +1939,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         String k2 = rnd();
         final Collection<BaseDocument> values = Arrays.asList(new BaseDocument(k1), new BaseDocument(k2), new BaseDocument(k2));
 
-        final MultiDocumentEntity<DocumentCreateEntity<BaseDocument>> docs = collection.insertDocuments(values);
+        final MultiDocumentEntity<?> docs = collection.insertDocuments(values);
         assertThat(docs).isNotNull();
         assertThat(docs.getDocuments()).isNotNull();
         assertThat(docs.getDocuments()).hasSize(2);
@@ -2340,7 +2340,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             e.setKey("2");
             values.add(e);
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
         keys.add("2");
@@ -2367,7 +2367,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             e.setKey("2");
             values.add(e);
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(values, null, null);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).hasSize(2);
@@ -2386,7 +2386,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             e.setKey("1");
             values.add(e);
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
         final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(keys, null, null);
@@ -2407,7 +2407,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             e.setKey("1");
             values.add(e);
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(values, null, null);
         assertThat(deleteResult).isNotNull();
         assertThat(deleteResult.getDocuments()).hasSize(1);
@@ -2421,7 +2421,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     @MethodSource("cols")
     void deleteDocumentsEmpty(ArangoCollection collection) {
         final Collection<BaseDocument> values = new ArrayList<>();
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<String> keys = new ArrayList<>();
         final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(keys, null, null);
         assertThat(deleteResult).isNotNull();
@@ -2433,7 +2433,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     @MethodSource("cols")
     void deleteDocumentsByKeyNotExisting(ArangoCollection collection) {
         final Collection<BaseDocument> values = new ArrayList<>();
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<String> keys = Arrays.asList(rnd(), rnd());
 
         final MultiDocumentEntity<DocumentDeleteEntity<Object>> deleteResult = collection.deleteDocuments(keys, null, null);
@@ -2466,7 +2466,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     @MethodSource("cols")
     void updateDocuments(ArangoCollection collection) {
         final Collection<BaseDocument> values = Arrays.asList(new BaseDocument(rnd()), new BaseDocument(rnd()));
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         values.forEach(it -> it.addAttribute("a", "test"));
 
         final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.updateDocuments(values, null);
@@ -2505,7 +2505,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             e.setKey("1");
             values.add(e);
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         final BaseDocument first = values.iterator().next();
         first.addAttribute("a", "test");
@@ -2531,7 +2531,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         {
             values.add(new BaseDocument("1"));
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         for (final BaseDocument i : values) {
             i.addAttribute("a", "test");
@@ -2567,7 +2567,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             values.add(new BaseDocument("1"));
             values.add(new BaseDocument("2"));
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         for (final BaseDocument i : values) {
             i.addAttribute("a", "test");
@@ -2587,7 +2587,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             e.setKey("1");
             values.add(e);
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         final BaseDocument first = values.iterator().next();
         first.addAttribute("a", "test");
@@ -2613,7 +2613,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         {
             values.add(new BaseDocument("1"));
         }
-        collection.insertDocuments(values, null);
+        collection.insertDocuments(values);
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         for (final BaseDocument i : values) {
             i.addAttribute("a", "test");

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -2469,7 +2469,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         collection.insertDocuments(values);
         values.forEach(it -> it.addAttribute("a", "test"));
 
-        final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.updateDocuments(values, null);
+        final MultiDocumentEntity<?> updateResult = collection.updateDocuments(values);
         assertThat(updateResult.getDocuments()).hasSize(2);
         assertThat(updateResult.getErrors()).isEmpty();
     }
@@ -2510,7 +2510,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         final BaseDocument first = values.iterator().next();
         first.addAttribute("a", "test");
         updatedValues.add(first);
-        final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.updateDocuments(updatedValues, null);
+        final MultiDocumentEntity<?> updateResult = collection.updateDocuments(updatedValues);
         assertThat(updateResult.getDocuments()).hasSize(1);
         assertThat(updateResult.getErrors()).isEmpty();
     }
@@ -2519,7 +2519,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     @MethodSource("cols")
     void updateDocumentsEmpty(ArangoCollection collection) {
         final Collection<BaseDocument> values = new ArrayList<>();
-        final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.updateDocuments(values, null);
+        final MultiDocumentEntity<?> updateResult = collection.updateDocuments(values);
         assertThat(updateResult.getDocuments()).isEmpty();
         assertThat(updateResult.getErrors()).isEmpty();
     }
@@ -2538,7 +2538,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             updatedValues.add(i);
         }
         updatedValues.add(new BaseDocument());
-        final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.updateDocuments(updatedValues, null);
+        final MultiDocumentEntity<?> updateResult = collection.updateDocuments(updatedValues);
         assertThat(updateResult.getDocuments()).hasSize(1);
         assertThat(updateResult.getErrors()).hasSize(1);
     }
@@ -2554,7 +2554,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         final Collection<RawJson> updatedValues = new ArrayList<>();
         updatedValues.add(RawJson.of("{\"_key\":\"1\", \"foo\":\"bar\"}"));
         updatedValues.add(RawJson.of("{\"_key\":\"2\", \"foo\":\"bar\"}"));
-        final MultiDocumentEntity<DocumentUpdateEntity<RawJson>> updateResult = collection.updateDocuments(updatedValues);
+        final MultiDocumentEntity<?> updateResult = collection.updateDocuments(updatedValues);
         assertThat(updateResult.getDocuments()).hasSize(2);
         assertThat(updateResult.getErrors()).isEmpty();
     }
@@ -2592,7 +2592,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         final BaseDocument first = values.iterator().next();
         first.addAttribute("a", "test");
         updatedValues.add(first);
-        final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.updateDocuments(updatedValues, null);
+        final MultiDocumentEntity<?> updateResult = collection.updateDocuments(updatedValues);
         assertThat(updateResult.getDocuments()).hasSize(1);
         assertThat(updateResult.getErrors()).isEmpty();
     }
@@ -2601,7 +2601,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     @MethodSource("cols")
     void replaceDocumentsEmpty(ArangoCollection collection) {
         final Collection<BaseDocument> values = new ArrayList<>();
-        final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.updateDocuments(values, null);
+        final MultiDocumentEntity<?> updateResult = collection.updateDocuments(values);
         assertThat(updateResult.getDocuments()).isEmpty();
         assertThat(updateResult.getErrors()).isEmpty();
     }
@@ -2620,7 +2620,7 @@ class ArangoCollectionTest extends BaseJunit5 {
             updatedValues.add(i);
         }
         updatedValues.add(new BaseDocument());
-        final MultiDocumentEntity<DocumentUpdateEntity<BaseDocument>> updateResult = collection.updateDocuments(updatedValues, null);
+        final MultiDocumentEntity<?> updateResult = collection.updateDocuments(updatedValues);
         assertThat(updateResult.getDocuments()).hasSize(1);
         assertThat(updateResult.getErrors()).hasSize(1);
     }

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -1151,7 +1151,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     void deleteDocument(ArangoCollection collection) {
         final BaseDocument doc = new BaseDocument(UUID.randomUUID().toString());
         final DocumentCreateEntity<BaseDocument> createResult = collection.insertDocument(doc, null);
-        collection.deleteDocument(createResult.getKey(), null, null);
+        collection.deleteDocument(createResult.getKey());
         final BaseDocument document = collection.getDocument(createResult.getKey(), BaseDocument.class, null);
         assertThat(document).isNull();
     }
@@ -1163,7 +1163,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         doc.addAttribute("a", "test");
         final DocumentCreateEntity<BaseDocument> createResult = collection.insertDocument(doc, null);
         final DocumentDeleteOptions options = new DocumentDeleteOptions().returnOld(true);
-        final DocumentDeleteEntity<BaseDocument> deleteResult = collection.deleteDocument(createResult.getKey(), BaseDocument.class, options);
+        final DocumentDeleteEntity<BaseDocument> deleteResult = collection.deleteDocument(createResult.getKey(), options, BaseDocument.class);
         assertThat(deleteResult.getOld()).isNotNull();
         assertThat(deleteResult.getOld()).isInstanceOf(BaseDocument.class);
         assertThat(deleteResult.getOld().getAttribute("a")).isNotNull();
@@ -1176,7 +1176,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         final BaseDocument doc = new BaseDocument(UUID.randomUUID().toString());
         final DocumentCreateEntity<BaseDocument> createResult = collection.insertDocument(doc, null);
         final DocumentDeleteOptions options = new DocumentDeleteOptions().ifMatch(createResult.getRev());
-        collection.deleteDocument(createResult.getKey(), null, options);
+        collection.deleteDocument(createResult.getKey(), options);
         final BaseDocument document = collection.getDocument(createResult.getKey(), BaseDocument.class, null);
         assertThat(document).isNull();
     }
@@ -1185,9 +1185,9 @@ class ArangoCollectionTest extends BaseJunit5 {
     @MethodSource("cols")
     void deleteDocumentIfMatchFail(ArangoCollection collection) {
         final BaseDocument doc = new BaseDocument(UUID.randomUUID().toString());
-        final DocumentCreateEntity<BaseDocument> createResult = collection.insertDocument(doc, null);
+        final DocumentCreateEntity<?> createResult = collection.insertDocument(doc);
         final DocumentDeleteOptions options = new DocumentDeleteOptions().ifMatch("no");
-        Throwable thrown = catchThrowable(() -> collection.deleteDocument(createResult.getKey(), null, options));
+        Throwable thrown = catchThrowable(() -> collection.deleteDocument(createResult.getKey(), options));
         assertThat(thrown).isInstanceOf(ArangoDBException.class);
     }
 
@@ -1196,7 +1196,7 @@ class ArangoCollectionTest extends BaseJunit5 {
     void deleteDocumentSilent(ArangoCollection collection) {
         assumeTrue(isSingleServer());
         final DocumentCreateEntity<?> createResult = collection.insertDocument(new BaseDocument());
-        final DocumentDeleteEntity<BaseDocument> meta = collection.deleteDocument(createResult.getKey(), BaseDocument.class, new DocumentDeleteOptions().silent(true));
+        final DocumentDeleteEntity<BaseDocument> meta = collection.deleteDocument(createResult.getKey(), new DocumentDeleteOptions().silent(true), BaseDocument.class);
         assertThat(meta).isNotNull();
         assertThat(meta.getId()).isNull();
         assertThat(meta.getKey()).isNull();

--- a/src/test/java/com/arangodb/DocumentTest.java
+++ b/src/test/java/com/arangodb/DocumentTest.java
@@ -83,7 +83,7 @@ class DocumentTest extends BaseJunit5 {
                         + "}"
         );
         //@formatter:on
-        final DocumentCreateEntity<RawJson> createResult = collection.insertDocument(json);
+        final DocumentCreateEntity<?> createResult = collection.insertDocument(json);
         final BaseDocument doc = collection.getDocument(createResult.getKey(), BaseDocument.class);
         assertThat(doc).isNotNull();
         final Object article = doc.getAttribute("article");
@@ -116,7 +116,7 @@ class DocumentTest extends BaseJunit5 {
             stock.addAttribute("status", "RMV");
             stock.addAttribute("lastUpdate", "2016-11-01 00:00");
         }
-        final DocumentCreateEntity<BaseDocument> createResult = collection.insertDocument(document);
+        final DocumentCreateEntity<?> createResult = collection.insertDocument(document);
         final BaseDocument doc = collection.getDocument(createResult.getKey(), BaseDocument.class);
         assertThat(doc).isNotNull();
         final Object article = doc.getAttribute("article");
@@ -131,7 +131,7 @@ class DocumentTest extends BaseJunit5 {
     void documentKeyWithSpecialChars(ArangoCollection collection) {
         final String key = "_-:.@()+,=;$!*'%" + UUID.randomUUID();
         final BaseDocument document = new BaseDocument(key);
-        final DocumentCreateEntity<BaseDocument> createResult = collection.insertDocument(document);
+        final DocumentCreateEntity<?> createResult = collection.insertDocument(document);
         final BaseDocument doc = collection.getDocument(createResult.getKey(), BaseDocument.class);
         assertThat(doc).isNotNull();
         assertThat(doc.getKey()).isEqualTo(key);

--- a/src/test/java/com/arangodb/StreamTransactionTest.java
+++ b/src/test/java/com/arangodb/StreamTransactionTest.java
@@ -552,7 +552,7 @@ class StreamTransactionTest extends BaseJunit5 {
 
         // delete document from within the tx
         collection
-                .deleteDocument(createdDoc.getKey(), null, new DocumentDeleteOptions().streamTransactionId(tx.getId()));
+                .deleteDocument(createdDoc.getKey(), new DocumentDeleteOptions().streamTransactionId(tx.getId()));
 
         // assert that the document has not been deleted from outside the tx
         assertThat(collection.getDocument(createdDoc.getKey(), BaseDocument.class, null)).isNotNull();

--- a/src/test/java/com/arangodb/StreamTransactionTest.java
+++ b/src/test/java/com/arangodb/StreamTransactionTest.java
@@ -576,7 +576,7 @@ class StreamTransactionTest extends BaseJunit5 {
 
         ArangoCollection collection = db.collection(COLLECTION_NAME);
         List<String> keys = collection
-                .insertDocuments(Arrays.asList(new BaseDocument(), new BaseDocument(), new BaseDocument()), null)
+                .insertDocuments(Arrays.asList(new BaseDocument(), new BaseDocument(), new BaseDocument()))
                 .getDocuments().stream().map(DocumentEntity::getKey).collect(Collectors.toList());
 
         StreamTransactionEntity tx = db.beginStreamTransaction(

--- a/src/test/java/com/arangodb/StreamTransactionTest.java
+++ b/src/test/java/com/arangodb/StreamTransactionTest.java
@@ -584,7 +584,7 @@ class StreamTransactionTest extends BaseJunit5 {
 
         // delete document from within the tx
         collection
-                .deleteDocuments(keys, null, new DocumentDeleteOptions().streamTransactionId(tx.getId()));
+                .deleteDocuments(keys, new DocumentDeleteOptions().streamTransactionId(tx.getId()));
 
         // assert that the documents has not been deleted from outside the tx
         assertThat(collection.getDocuments(keys, BaseDocument.class, null).getDocuments()).hasSize(keys.size());

--- a/src/test/java/com/arangodb/async/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/async/ArangoCollectionTest.java
@@ -2157,7 +2157,7 @@ class ArangoCollectionTest extends BaseTest {
             i.addAttribute("a", "test");
             updatedValues.add(i);
         }
-        db.collection(COLLECTION_NAME).replaceDocuments(updatedValues, null)
+        db.collection(COLLECTION_NAME).replaceDocuments(updatedValues)
                 .whenComplete((updateResult, ex) -> {
                     assertThat(updateResult.getDocuments().size()).isEqualTo(2);
                     assertThat(updateResult.getErrors().size()).isEqualTo(0);

--- a/src/test/java/com/arangodb/async/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/async/ArangoCollectionTest.java
@@ -1899,11 +1899,11 @@ class ArangoCollectionTest extends BaseTest {
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
         keys.add("2");
-        db.collection(COLLECTION_NAME).deleteDocuments(keys, null, null)
+        db.collection(COLLECTION_NAME).deleteDocuments(keys)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
                     assertThat(deleteResult.getDocuments().size()).isEqualTo(2);
-                    for (final DocumentDeleteEntity<Object> i : deleteResult.getDocuments()) {
+                    for (final DocumentDeleteEntity<?> i : deleteResult.getDocuments()) {
                         assertThat(i.getKey()).isIn("1", "2");
                     }
                     assertThat(deleteResult.getErrors().size()).isEqualTo(0);
@@ -1925,11 +1925,11 @@ class ArangoCollectionTest extends BaseTest {
             values.add(e);
         }
         db.collection(COLLECTION_NAME).insertDocuments(values).get();
-        db.collection(COLLECTION_NAME).deleteDocuments(values, null, null)
+        db.collection(COLLECTION_NAME).deleteDocuments(values)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
                     assertThat(deleteResult.getDocuments().size()).isEqualTo(2);
-                    for (final DocumentDeleteEntity<Object> i : deleteResult.getDocuments()) {
+                    for (final DocumentDeleteEntity<?> i : deleteResult.getDocuments()) {
                         assertThat(i.getKey()).isIn("1", "2");
                     }
                     assertThat(deleteResult.getErrors().size()).isEqualTo(0);
@@ -1948,11 +1948,11 @@ class ArangoCollectionTest extends BaseTest {
         db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
-        db.collection(COLLECTION_NAME).deleteDocuments(keys, null, null)
+        db.collection(COLLECTION_NAME).deleteDocuments(keys)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
                     assertThat(deleteResult.getDocuments().size()).isEqualTo(1);
-                    for (final DocumentDeleteEntity<Object> i : deleteResult.getDocuments()) {
+                    for (final DocumentDeleteEntity<?> i : deleteResult.getDocuments()) {
                         assertThat(i.getKey()).isEqualTo("1");
                     }
                     assertThat(deleteResult.getErrors().size()).isEqualTo(0);
@@ -1969,11 +1969,11 @@ class ArangoCollectionTest extends BaseTest {
             values.add(e);
         }
         db.collection(COLLECTION_NAME).insertDocuments(values).get();
-        db.collection(COLLECTION_NAME).deleteDocuments(values, null, null)
+        db.collection(COLLECTION_NAME).deleteDocuments(values)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
                     assertThat(deleteResult.getDocuments().size()).isEqualTo(1);
-                    for (final DocumentDeleteEntity<Object> i : deleteResult.getDocuments()) {
+                    for (final DocumentDeleteEntity<?> i : deleteResult.getDocuments()) {
                         assertThat(i.getKey()).isEqualTo("1");
                     }
                     assertThat(deleteResult.getErrors().size()).isEqualTo(0);
@@ -1986,7 +1986,7 @@ class ArangoCollectionTest extends BaseTest {
         final Collection<BaseDocument> values = new ArrayList<>();
         db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<String> keys = new ArrayList<>();
-        db.collection(COLLECTION_NAME).deleteDocuments(keys, null, null)
+        db.collection(COLLECTION_NAME).deleteDocuments(keys)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
                     assertThat(deleteResult.getDocuments().size()).isEqualTo(0);
@@ -2002,7 +2002,7 @@ class ArangoCollectionTest extends BaseTest {
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
         keys.add("2");
-        db.collection(COLLECTION_NAME).deleteDocuments(keys, null, null)
+        db.collection(COLLECTION_NAME).deleteDocuments(keys)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
                     assertThat(deleteResult.getDocuments().size()).isEqualTo(0);
@@ -2024,7 +2024,7 @@ class ArangoCollectionTest extends BaseTest {
             e.setKey("2");
             values.add(e);
         }
-        db.collection(COLLECTION_NAME).deleteDocuments(values, null, null)
+        db.collection(COLLECTION_NAME).deleteDocuments(values)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
                     assertThat(deleteResult.getDocuments().size()).isEqualTo(0);

--- a/src/test/java/com/arangodb/async/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/async/ArangoCollectionTest.java
@@ -1427,7 +1427,7 @@ class ArangoCollectionTest extends BaseTest {
         values.add(new BaseDocument());
         values.add(new BaseDocument());
         values.add(new BaseDocument());
-        db.collection(COLLECTION_NAME).insertDocuments(values, null)
+        db.collection(COLLECTION_NAME).insertDocuments(values)
                 .whenComplete((docs, ex) -> {
                     assertThat(docs).isNotNull();
                     assertThat(docs.getDocuments()).isNotNull();
@@ -1442,7 +1442,7 @@ class ArangoCollectionTest extends BaseTest {
     void insertDocumentsOne() throws InterruptedException, ExecutionException {
         final Collection<BaseDocument> values = new ArrayList<>();
         values.add(new BaseDocument());
-        db.collection(COLLECTION_NAME).insertDocuments(values, null)
+        db.collection(COLLECTION_NAME).insertDocuments(values)
                 .whenComplete((docs, ex) -> {
                     assertThat(docs).isNotNull();
                     assertThat(docs.getDocuments()).isNotNull();
@@ -1456,7 +1456,7 @@ class ArangoCollectionTest extends BaseTest {
     @Test
     void insertDocumentsEmpty() throws InterruptedException, ExecutionException {
         final Collection<BaseDocument> values = new ArrayList<>();
-        db.collection(COLLECTION_NAME).insertDocuments(values, null)
+        db.collection(COLLECTION_NAME).insertDocuments(values)
                 .whenComplete((docs, ex) -> {
                     assertThat(docs).isNotNull();
                     assertThat(docs.getDocuments()).isNotNull();
@@ -1895,7 +1895,7 @@ class ArangoCollectionTest extends BaseTest {
             e.setKey("2");
             values.add(e);
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
         keys.add("2");
@@ -1924,7 +1924,7 @@ class ArangoCollectionTest extends BaseTest {
             e.setKey("2");
             values.add(e);
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         db.collection(COLLECTION_NAME).deleteDocuments(values, null, null)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
@@ -1945,7 +1945,7 @@ class ArangoCollectionTest extends BaseTest {
             e.setKey("1");
             values.add(e);
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
         db.collection(COLLECTION_NAME).deleteDocuments(keys, null, null)
@@ -1968,7 +1968,7 @@ class ArangoCollectionTest extends BaseTest {
             e.setKey("1");
             values.add(e);
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         db.collection(COLLECTION_NAME).deleteDocuments(values, null, null)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult).isNotNull();
@@ -1984,7 +1984,7 @@ class ArangoCollectionTest extends BaseTest {
     @Test
     void deleteDocumentsEmpty() throws InterruptedException, ExecutionException {
         final Collection<BaseDocument> values = new ArrayList<>();
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<String> keys = new ArrayList<>();
         db.collection(COLLECTION_NAME).deleteDocuments(keys, null, null)
                 .whenComplete((deleteResult, ex) -> {
@@ -1998,7 +1998,7 @@ class ArangoCollectionTest extends BaseTest {
     @Test
     void deleteDocumentsByKeyNotExisting() throws InterruptedException, ExecutionException {
         final Collection<BaseDocument> values = new ArrayList<>();
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<String> keys = new ArrayList<>();
         keys.add("1");
         keys.add("2");
@@ -2046,13 +2046,13 @@ class ArangoCollectionTest extends BaseTest {
             e.setKey("2");
             values.add(e);
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         for (final BaseDocument i : values) {
             i.addAttribute("a", "test");
             updatedValues.add(i);
         }
-        db.collection(COLLECTION_NAME).updateDocuments(updatedValues, null)
+        db.collection(COLLECTION_NAME).updateDocuments(updatedValues)
                 .whenComplete((updateResult, ex) -> {
                     assertThat(updateResult.getDocuments().size()).isEqualTo(2);
                     assertThat(updateResult.getErrors().size()).isEqualTo(0);
@@ -2099,7 +2099,7 @@ class ArangoCollectionTest extends BaseTest {
             e.setKey("1");
             values.add(e);
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         final BaseDocument first = values.iterator().next();
         first.addAttribute("a", "test");
@@ -2129,7 +2129,7 @@ class ArangoCollectionTest extends BaseTest {
         {
             values.add(new BaseDocument("1"));
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         for (final BaseDocument i : values) {
             i.addAttribute("a", "test");
@@ -2151,7 +2151,7 @@ class ArangoCollectionTest extends BaseTest {
             values.add(new BaseDocument("1"));
             values.add(new BaseDocument("2"));
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         for (final BaseDocument i : values) {
             i.addAttribute("a", "test");
@@ -2173,7 +2173,7 @@ class ArangoCollectionTest extends BaseTest {
             e.setKey("1");
             values.add(e);
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         final BaseDocument first = values.iterator().next();
         first.addAttribute("a", "test");
@@ -2203,7 +2203,7 @@ class ArangoCollectionTest extends BaseTest {
         {
             values.add(new BaseDocument("1"));
         }
-        db.collection(COLLECTION_NAME).insertDocuments(values, null).get();
+        db.collection(COLLECTION_NAME).insertDocuments(values).get();
         final Collection<BaseDocument> updatedValues = new ArrayList<>();
         for (final BaseDocument i : values) {
             i.addAttribute("a", "test");

--- a/src/test/java/com/arangodb/async/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/async/ArangoCollectionTest.java
@@ -791,7 +791,7 @@ class ArangoCollectionTest extends BaseTest {
         final BaseDocument doc = new BaseDocument(UUID.randomUUID().toString());
         final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME).insertDocument(doc, null)
                 .get();
-        db.collection(COLLECTION_NAME).deleteDocument(createResult.getKey(), null, null).get();
+        db.collection(COLLECTION_NAME).deleteDocument(createResult.getKey()).get();
         db.collection(COLLECTION_NAME).getDocument(createResult.getKey(), BaseDocument.class, null)
                 .whenComplete((document, ex) -> assertThat(document).isNull())
                 .get();
@@ -804,7 +804,7 @@ class ArangoCollectionTest extends BaseTest {
         final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME).insertDocument(doc, null)
                 .get();
         final DocumentDeleteOptions options = new DocumentDeleteOptions().returnOld(true);
-        db.collection(COLLECTION_NAME).deleteDocument(createResult.getKey(), BaseDocument.class, options)
+        db.collection(COLLECTION_NAME).deleteDocument(createResult.getKey(), options, BaseDocument.class)
                 .whenComplete((deleteResult, ex) -> {
                     assertThat(deleteResult.getOld()).isNotNull();
                     assertThat(deleteResult.getOld()).isInstanceOf(BaseDocument.class);
@@ -820,7 +820,7 @@ class ArangoCollectionTest extends BaseTest {
         final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME).insertDocument(doc, null)
                 .get();
         final DocumentDeleteOptions options = new DocumentDeleteOptions().ifMatch(createResult.getRev());
-        db.collection(COLLECTION_NAME).deleteDocument(createResult.getKey(), null, options).get();
+        db.collection(COLLECTION_NAME).deleteDocument(createResult.getKey(), options).get();
         db.collection(COLLECTION_NAME).getDocument(createResult.getKey(), BaseDocument.class, null)
                 .whenComplete((document, ex) -> assertThat(document).isNull())
                 .get();
@@ -833,7 +833,7 @@ class ArangoCollectionTest extends BaseTest {
                 .get();
         final DocumentDeleteOptions options = new DocumentDeleteOptions().ifMatch("no");
         try {
-            db.collection(COLLECTION_NAME).deleteDocument(createResult.getKey(), null, options).get();
+            db.collection(COLLECTION_NAME).deleteDocument(createResult.getKey(), options).get();
             fail();
         } catch (final ExecutionException e) {
             assertThat(e.getCause()).isInstanceOf(ArangoDBException.class);

--- a/src/test/java/com/arangodb/async/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/async/ArangoCollectionTest.java
@@ -2104,7 +2104,7 @@ class ArangoCollectionTest extends BaseTest {
         final BaseDocument first = values.iterator().next();
         first.addAttribute("a", "test");
         updatedValues.add(first);
-        db.collection(COLLECTION_NAME).updateDocuments(updatedValues, null)
+        db.collection(COLLECTION_NAME).updateDocuments(updatedValues)
                 .whenComplete((updateResult, ex) -> {
                     assertThat(updateResult.getDocuments().size()).isEqualTo(1);
                     assertThat(updateResult.getErrors().size()).isEqualTo(0);
@@ -2115,7 +2115,7 @@ class ArangoCollectionTest extends BaseTest {
     @Test
     void updateDocumentsEmpty() throws InterruptedException, ExecutionException {
         final Collection<BaseDocument> values = new ArrayList<>();
-        db.collection(COLLECTION_NAME).updateDocuments(values, null)
+        db.collection(COLLECTION_NAME).updateDocuments(values)
                 .whenComplete((updateResult, ex) -> {
                     assertThat(updateResult.getDocuments().size()).isEqualTo(0);
                     assertThat(updateResult.getErrors().size()).isEqualTo(0);
@@ -2136,7 +2136,7 @@ class ArangoCollectionTest extends BaseTest {
             updatedValues.add(i);
         }
         updatedValues.add(new BaseDocument());
-        db.collection(COLLECTION_NAME).updateDocuments(updatedValues, null)
+        db.collection(COLLECTION_NAME).updateDocuments(updatedValues)
                 .whenComplete((updateResult, ex) -> {
                     assertThat(updateResult.getDocuments().size()).isEqualTo(1);
                     assertThat(updateResult.getErrors().size()).isEqualTo(1);
@@ -2178,7 +2178,7 @@ class ArangoCollectionTest extends BaseTest {
         final BaseDocument first = values.iterator().next();
         first.addAttribute("a", "test");
         updatedValues.add(first);
-        db.collection(COLLECTION_NAME).updateDocuments(updatedValues, null)
+        db.collection(COLLECTION_NAME).updateDocuments(updatedValues)
                 .whenComplete((updateResult, ex) -> {
                     assertThat(updateResult.getDocuments().size()).isEqualTo(1);
                     assertThat(updateResult.getErrors().size()).isEqualTo(0);
@@ -2189,7 +2189,7 @@ class ArangoCollectionTest extends BaseTest {
     @Test
     void replaceDocumentsEmpty() throws InterruptedException, ExecutionException {
         final Collection<BaseDocument> values = new ArrayList<>();
-        db.collection(COLLECTION_NAME).updateDocuments(values, null)
+        db.collection(COLLECTION_NAME).updateDocuments(values)
                 .whenComplete((updateResult, ex) -> {
                     assertThat(updateResult.getDocuments().size()).isEqualTo(0);
                     assertThat(updateResult.getErrors().size()).isEqualTo(0);
@@ -2210,7 +2210,7 @@ class ArangoCollectionTest extends BaseTest {
             updatedValues.add(i);
         }
         updatedValues.add(new BaseDocument());
-        db.collection(COLLECTION_NAME).updateDocuments(updatedValues, null)
+        db.collection(COLLECTION_NAME).updateDocuments(updatedValues)
                 .whenComplete((updateResult, ex) -> {
                     assertThat(updateResult.getDocuments().size()).isEqualTo(1);
                     assertThat(updateResult.getErrors().size()).isEqualTo(1);

--- a/src/test/java/com/arangodb/async/example/document/GetDocumentExampleTest.java
+++ b/src/test/java/com/arangodb/async/example/document/GetDocumentExampleTest.java
@@ -46,8 +46,7 @@ class GetDocumentExampleTest extends ExampleBase {
     static void before() throws InterruptedException, ExecutionException {
         final BaseDocument value = new BaseDocument(UUID.randomUUID().toString());
         value.addAttribute("foo", "bar");
-        final DocumentCreateEntity<BaseDocument> doc = collection.insertDocument(value).get();
-        key = doc.getKey();
+        key = collection.insertDocument(value).get().getKey();
     }
 
     @Test

--- a/src/test/java/com/arangodb/async/example/graph/AQLActorsAndMoviesExampleTest.java
+++ b/src/test/java/com/arangodb/async/example/graph/AQLActorsAndMoviesExampleTest.java
@@ -72,7 +72,7 @@ class AQLActorsAndMoviesExampleTest {
         arangoDB.shutdown();
     }
 
-    private static DocumentCreateEntity<BaseDocument> saveMovie(
+    private static DocumentCreateEntity<?> saveMovie(
             final ArangoCollectionAsync movies,
             final String key,
             final String title,
@@ -86,7 +86,7 @@ class AQLActorsAndMoviesExampleTest {
         return movies.insertDocument(value).get();
     }
 
-    private static DocumentCreateEntity<BaseDocument> saveActor(
+    private static DocumentCreateEntity<?> saveActor(
             final ArangoCollectionAsync actors,
             final String key,
             final String name,

--- a/src/test/java/com/arangodb/async/serde/CustomSerdeTest.java
+++ b/src/test/java/com/arangodb/async/serde/CustomSerdeTest.java
@@ -115,7 +115,7 @@ class CustomSerdeTest {
         doc.put("arr", Collections.singletonList("hello"));
         doc.put("int", 10);
 
-        collection.insertDocument(doc, null).get();
+        collection.insertDocument(doc).get();
 
         final Map<String, Object> result = db.query(
                 "RETURN DOCUMENT(@docId)",
@@ -158,7 +158,7 @@ class CustomSerdeTest {
         doc.put("arr", Collections.singletonList("hello"));
         doc.put("int", 10);
 
-        collection.insertDocument(doc, null).get();
+        collection.insertDocument(doc).get();
 
         final Map<String, Object> result = db.collection(COLLECTION_NAME).getDocument(
                 key,

--- a/src/test/java/com/arangodb/example/document/GetDocumentExampleTest.java
+++ b/src/test/java/com/arangodb/example/document/GetDocumentExampleTest.java
@@ -46,8 +46,7 @@ class GetDocumentExampleTest extends ExampleBase {
     static void before() {
         final BaseDocument value = new BaseDocument(UUID.randomUUID().toString());
         value.addAttribute("foo", "bar");
-        final DocumentCreateEntity<BaseDocument> doc = collection.insertDocument(value);
-        key = doc.getKey();
+        key = collection.insertDocument(value).getKey();
     }
 
     @Test

--- a/src/test/java/com/arangodb/example/document/InsertDocumentExampleTest.java
+++ b/src/test/java/com/arangodb/example/document/InsertDocumentExampleTest.java
@@ -24,7 +24,6 @@ import com.arangodb.entity.BaseDocument;
 import com.arangodb.entity.DocumentCreateEntity;
 import com.arangodb.example.ExampleBase;
 import com.arangodb.util.RawJson;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,7 @@ class InsertDocumentExampleTest extends ExampleBase {
 
     @Test
     void insertBean() {
-        final DocumentCreateEntity<TestEntity> doc = collection.insertDocument(new TestEntity("bar"));
+        final DocumentCreateEntity<?> doc = collection.insertDocument(new TestEntity("bar"));
         assertThat(doc.getKey()).isNotNull();
     }
 
@@ -49,7 +48,7 @@ class InsertDocumentExampleTest extends ExampleBase {
     void insertBaseDocument() {
         final BaseDocument value = new BaseDocument(UUID.randomUUID().toString());
         value.addAttribute("foo", "bar");
-        final DocumentCreateEntity<BaseDocument> doc = collection.insertDocument(value);
+        final DocumentCreateEntity<?> doc = collection.insertDocument(value);
         assertThat(doc.getKey()).isNotNull();
     }
 
@@ -58,13 +57,13 @@ class InsertDocumentExampleTest extends ExampleBase {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode node = mapper.createObjectNode();
         node.put("foo", "bar");
-        final DocumentCreateEntity<JsonNode> doc = collection.insertDocument(node);
+        final DocumentCreateEntity<?> doc = collection.insertDocument(node);
         assertThat(doc.getKey()).isNotNull();
     }
 
     @Test
     void insertJson() {
-        final DocumentCreateEntity<RawJson> doc = collection.insertDocument(RawJson.of("{\"foo\":\"bar\"}"));
+        final DocumentCreateEntity<?> doc = collection.insertDocument(RawJson.of("{\"foo\":\"bar\"}"));
         assertThat(doc.getKey()).isNotNull();
     }
 

--- a/src/test/java/com/arangodb/example/graph/AQLActorsAndMoviesExampleTest.java
+++ b/src/test/java/com/arangodb/example/graph/AQLActorsAndMoviesExampleTest.java
@@ -313,7 +313,7 @@ class AQLActorsAndMoviesExampleTest {
 
     }
 
-    private static DocumentCreateEntity<BaseDocument> saveMovie(
+    private static DocumentCreateEntity<?> saveMovie(
             final ArangoCollection movies,
             final String key,
             final String title,
@@ -327,7 +327,7 @@ class AQLActorsAndMoviesExampleTest {
         return movies.insertDocument(value);
     }
 
-    private static DocumentCreateEntity<BaseDocument> saveActor(
+    private static DocumentCreateEntity<?> saveActor(
             final ArangoCollection actors,
             final String key,
             final String name,

--- a/src/test/java/com/arangodb/serde/CustomSerdeTest.java
+++ b/src/test/java/com/arangodb/serde/CustomSerdeTest.java
@@ -171,7 +171,7 @@ class CustomSerdeTest {
         doc.put("arr", Collections.singletonList("hello"));
         doc.put("int", 10);
 
-        collection.insertDocument(doc, null);
+        collection.insertDocument(doc);
 
         final Map<String, Object> result = db.query(
                 "RETURN DOCUMENT(@docId)",
@@ -214,7 +214,7 @@ class CustomSerdeTest {
         doc.put("arr", Collections.singletonList("hello"));
         doc.put("int", 10);
 
-        collection.insertDocument(doc, null);
+        collection.insertDocument(doc);
 
         final Map<String, Object> result = db.collection(COLLECTION_NAME).getDocument(
                 key,


### PR DESCRIPTION
CRUD document operations should allow specifying the return type, instead of capturing the runtime type of the object(s) being saved. I.e. currently we cannot save polymorphic collections of documents.

Covariance of returned types will be fixed in a subsequent PR.

---

fixes #373 