### PR TITLE
[DE-371] cluster dirty reads

### DIFF
--- a/src/main/java/com/arangodb/ArangoCursor.java
+++ b/src/main/java/com/arangodb/ArangoCursor.java
@@ -70,4 +70,6 @@ public interface ArangoCursor<T> extends ArangoIterable<T>, ArangoIterator<T>, C
      */
     List<T> asListRemaining();
 
+    boolean isPotentialDirtyRead();
+
 }

--- a/src/main/java/com/arangodb/ArangoCursor.java
+++ b/src/main/java/com/arangodb/ArangoCursor.java
@@ -70,6 +70,10 @@ public interface ArangoCursor<T> extends ArangoIterable<T>, ArangoIterator<T>, C
      */
     List<T> asListRemaining();
 
+    /**
+     * @return true if the result is a potential dirty read
+     * @since ArangoDB 3.10
+     */
     boolean isPotentialDirtyRead();
 
 }

--- a/src/main/java/com/arangodb/entity/CursorEntity.java
+++ b/src/main/java/com/arangodb/entity/CursorEntity.java
@@ -88,6 +88,7 @@ public class CursorEntity implements Entity, MetaAware {
     }
 
     public Map<String, String> getMeta() {
+        if (meta == null) return Collections.emptyMap();
         return meta;
     }
 

--- a/src/main/java/com/arangodb/entity/MultiDocumentEntity.java
+++ b/src/main/java/com/arangodb/entity/MultiDocumentEntity.java
@@ -69,6 +69,10 @@ public class MultiDocumentEntity<E> implements Entity {
         this.documentsAndErrors = documentsAndErrors;
     }
 
+    /**
+     * @return true if the result is a potential dirty read
+     * @since ArangoDB 3.10
+     */
     public Boolean isPotentialDirtyRead() {
         return isPotentialDirtyRead;
     }

--- a/src/main/java/com/arangodb/entity/MultiDocumentEntity.java
+++ b/src/main/java/com/arangodb/entity/MultiDocumentEntity.java
@@ -30,6 +30,7 @@ public class MultiDocumentEntity<E> implements Entity {
     private Collection<E> documents;
     private Collection<ErrorEntity> errors;
     private Collection<Object> documentsAndErrors;
+    private boolean isPotentialDirtyRead = false;
 
     public MultiDocumentEntity() {
         super();
@@ -68,4 +69,11 @@ public class MultiDocumentEntity<E> implements Entity {
         this.documentsAndErrors = documentsAndErrors;
     }
 
+    public Boolean isPotentialDirtyRead() {
+        return isPotentialDirtyRead;
+    }
+
+    public void setPotentialDirtyRead(final Boolean isPotentialDirtyRead) {
+        this.isPotentialDirtyRead = isPotentialDirtyRead;
+    }
 }

--- a/src/main/java/com/arangodb/internal/InternalArangoCollection.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoCollection.java
@@ -229,6 +229,8 @@ public abstract class InternalArangoCollection<A extends InternalArangoDB<E>, D 
             final Class<T> type, final DocumentReadOptions options) {
         return response -> {
             final MultiDocumentEntity<T> multiDocument = new MultiDocumentEntity<>();
+            boolean potentialDirtyRead = Boolean.parseBoolean(response.getMeta().get("X-Arango-Potential-Dirty-Read"));
+            multiDocument.setPotentialDirtyRead(potentialDirtyRead);
             final Collection<T> docs = new ArrayList<>();
             final Collection<ErrorEntity> errors = new ArrayList<>();
             final Collection<Object> documentsAndErrors = new ArrayList<>();

--- a/src/main/java/com/arangodb/internal/InternalArangoDatabase.java
+++ b/src/main/java/com/arangodb/internal/InternalArangoDatabase.java
@@ -361,8 +361,13 @@ public abstract class InternalArangoDatabase<A extends InternalArangoDB<EXECUTOR
     }
 
     protected Request beginStreamTransactionRequest(final StreamTransactionOptions options) {
-        return request(dbName, RequestType.POST, PATH_API_BEGIN_STREAM_TRANSACTION)
-                .setBody(util().serialize(options != null ? options : new StreamTransactionOptions()));
+        StreamTransactionOptions opts = options != null ? options : new StreamTransactionOptions();
+        Request r = request(dbName, RequestType.POST, PATH_API_BEGIN_STREAM_TRANSACTION)
+                .setBody(util().serialize(opts));
+        if(Boolean.TRUE.equals(opts.getAllowDirtyRead())) {
+            RequestUtils.allowDirtyRead(r);
+        }
+        return r;
     }
 
     protected Request abortStreamTransactionRequest(String id) {

--- a/src/main/java/com/arangodb/internal/cursor/ArangoCursorImpl.java
+++ b/src/main/java/com/arangodb/internal/cursor/ArangoCursorImpl.java
@@ -43,6 +43,7 @@ public class ArangoCursorImpl<T> extends AbstractArangoIterable<T> implements Ar
     protected final ArangoCursorIterator<T> iterator;
     private final String id;
     private final ArangoCursorExecute execute;
+    private final boolean isPontentialDirtyRead;
 
     public ArangoCursorImpl(final InternalArangoDatabase<?, ?> db, final ArangoCursorExecute execute,
                             final Class<T> type, final CursorEntity result) {
@@ -51,6 +52,7 @@ public class ArangoCursorImpl<T> extends AbstractArangoIterable<T> implements Ar
         this.type = type;
         iterator = createIterator(this, db, execute, result);
         id = result.getId();
+        this.isPontentialDirtyRead = Boolean.parseBoolean(result.getMeta().get("X-Arango-Potential-Dirty-Read"));
     }
 
     protected ArangoCursorIterator<T> createIterator(
@@ -118,6 +120,11 @@ public class ArangoCursorImpl<T> extends AbstractArangoIterable<T> implements Ar
             remaining.add(next());
         }
         return remaining;
+    }
+
+    @Override
+    public boolean isPotentialDirtyRead() {
+        return isPontentialDirtyRead;
     }
 
     @Override

--- a/src/main/java/com/arangodb/model/StreamTransactionOptions.java
+++ b/src/main/java/com/arangodb/model/StreamTransactionOptions.java
@@ -20,6 +20,8 @@
 
 package com.arangodb.model;
 
+import com.arangodb.velocypack.annotations.Expose;
+
 /**
  * @author Mark Vollmary
  * @author Michele Rastelli
@@ -33,6 +35,8 @@ public class StreamTransactionOptions {
     private Boolean waitForSync;
     private Long maxTransactionSize;
     private Boolean allowImplicit;
+    @Expose(serialize = false)
+    private Boolean allowDirtyRead;
 
     public StreamTransactionOptions() {
         super();
@@ -120,6 +124,22 @@ public class StreamTransactionOptions {
      */
     public StreamTransactionOptions maxTransactionSize(final Long maxTransactionSize) {
         this.maxTransactionSize = maxTransactionSize;
+        return this;
+    }
+
+    public Boolean getAllowDirtyRead() {
+        return allowDirtyRead;
+    }
+
+    /**
+     * @param allowDirtyRead Set to {@code true} allows reading from followers in an active-failover setup.
+     * @return options
+     * @see <a href="https://www.arangodb.com/docs/stable/administration-active-failover.html#reading-from-follower">API
+     * Documentation</a>
+     * @since ArangoDB 3.4.0
+     */
+    public StreamTransactionOptions allowDirtyRead(final Boolean allowDirtyRead) {
+        this.allowDirtyRead = allowDirtyRead;
         return this;
     }
 

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -524,7 +524,9 @@ class ArangoCollectionTest extends BaseJunit5 {
                 .getDocuments(Arrays.asList("1", "2", "3"), BaseDocument.class,
                         new DocumentReadOptions().allowDirtyRead(true));
         assertThat(documents).isNotNull();
-        assertThat(documents.isPotentialDirtyRead()).isTrue();
+        if (isAtLeastVersion(3, 10)) {
+            assertThat(documents.isPotentialDirtyRead()).isTrue();
+        }
         assertThat(documents.getDocuments()).hasSize(3);
         for (final BaseDocument document : documents.getDocuments()) {
             assertThat(document.getId()).isIn(COLLECTION_NAME + "/" + "1", COLLECTION_NAME + "/" + "2", COLLECTION_NAME + "/" + "3");

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -524,6 +524,7 @@ class ArangoCollectionTest extends BaseJunit5 {
                 .getDocuments(Arrays.asList("1", "2", "3"), BaseDocument.class,
                         new DocumentReadOptions().allowDirtyRead(true));
         assertThat(documents).isNotNull();
+        assertThat(documents.isPotentialDirtyRead()).isTrue();
         assertThat(documents.getDocuments()).hasSize(3);
         for (final BaseDocument document : documents.getDocuments()) {
             assertThat(document.getId()).isIn(COLLECTION_NAME + "/" + "1", COLLECTION_NAME + "/" + "2", COLLECTION_NAME + "/" + "3");

--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -959,7 +959,9 @@ class ArangoDatabaseTest extends BaseJunit5 {
         final ArangoCursor<BaseDocument> cursor = db.query("FOR i IN @@col FILTER i.test == @test RETURN i",
                 new MapBuilder().put("@col", CNAME1).put("test", null).get(),
                 new AqlQueryOptions().allowDirtyRead(true), BaseDocument.class);
-        assertThat(cursor.isPotentialDirtyRead()).isTrue();
+        if (isAtLeastVersion(3, 10)) {
+            assertThat(cursor.isPotentialDirtyRead()).isTrue();
+        }
         cursor.close();
     }
 

--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -959,6 +959,7 @@ class ArangoDatabaseTest extends BaseJunit5 {
         final ArangoCursor<BaseDocument> cursor = db.query("FOR i IN @@col FILTER i.test == @test RETURN i",
                 new MapBuilder().put("@col", CNAME1).put("test", null).get(),
                 new AqlQueryOptions().allowDirtyRead(true), BaseDocument.class);
+        assertThat(cursor.isPotentialDirtyRead()).isTrue();
         cursor.close();
     }
 


### PR DESCRIPTION
- [x]    Single document reads (GET /_api/document)
- [x]    Batch document reads (PUT /_api/document?onlyget=true)
- [x]    Read-only AQL queries (POST /_api/cursor)
- [x]    The edge API (GET /_api/edges)
- [x]    Read-only Stream Transactions and their sub-operations (POST /_api/transaction/begin etc.)
