### PR TITLE
[DE-636] Non-interfering Jackson annotations

### DIFF
--- a/driver/src/test/java/com/arangodb/serde/JacksonInterferenceTest.java
+++ b/driver/src/test/java/com/arangodb/serde/JacksonInterferenceTest.java
@@ -1,0 +1,35 @@
+package com.arangodb.serde;
+
+import com.arangodb.serde.jackson.Id;
+import com.arangodb.serde.jackson.Key;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JacksonInterferenceTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    static class Foo {
+        @Id
+        public String myId;
+
+        @Key
+        public String myKey;
+
+        Foo(String id, String key) {
+            myId = id;
+            myKey = key;
+        }
+    }
+
+    @Test
+    void serialize() {
+        Foo foo = new Foo("foo", "bar");
+        ObjectNode node = mapper.convertValue(foo, ObjectNode.class);
+//        assertThat(node.get("myId").textValue()).isEqualTo("foo");
+        assertThat(node.get("myKey").textValue()).isEqualTo("bar");
+    }
+}

--- a/driver/src/test/java/com/arangodb/serde/JacksonInterferenceTest.java
+++ b/driver/src/test/java/com/arangodb/serde/JacksonInterferenceTest.java
@@ -1,35 +1,237 @@
 package com.arangodb.serde;
 
-import com.arangodb.serde.jackson.Id;
-import com.arangodb.serde.jackson.Key;
+import com.arangodb.serde.jackson.*;
+import com.arangodb.serde.jackson.json.JacksonJsonSerdeProvider;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JacksonInterferenceTest {
 
     private final ObjectMapper mapper = new ObjectMapper();
+    private final ArangoSerde serde = new JacksonJsonSerdeProvider().create();
 
-    static class Foo {
+    private FooField fooField;
+    private FooProp fooProp;
+
+    static class FooField {
         @Id
         public String myId;
-
         @Key
         public String myKey;
+        @Rev
+        public String myRev;
+        @From
+        public String myFrom;
+        @To
+        public String myTo;
+    }
 
-        Foo(String id, String key) {
-            myId = id;
-            myKey = key;
+    static class FooProp {
+        public String myId;
+        public String myKey;
+        public String myRev;
+        public String myFrom;
+        public String myTo;
+
+        @Id
+        public String getMyId() {
+            return myId;
+        }
+
+        @Id
+        public void setMyId(String myId) {
+            this.myId = myId;
+        }
+
+        @Key
+        public String getMyKey() {
+            return myKey;
+        }
+
+        @Key
+        public void setMyKey(String myKey) {
+            this.myKey = myKey;
+        }
+
+        @Rev
+        public String getMyRev() {
+            return myRev;
+        }
+
+        @Rev
+        public void setMyRev(String myRev) {
+            this.myRev = myRev;
+        }
+
+        @From
+        public String getMyFrom() {
+            return myFrom;
+        }
+
+        @From
+        public void setMyFrom(String myFrom) {
+            this.myFrom = myFrom;
+        }
+
+        @To
+        public String getMyTo() {
+            return myTo;
+        }
+
+        @To
+        public void setMyTo(String myTo) {
+            this.myTo = myTo;
         }
     }
 
+    @BeforeEach
+    void init() {
+        fooField = new FooField();
+        fooProp = new FooProp();
+
+        fooField.myId = "myId";
+        fooProp.myId = "myId";
+
+        fooField.myKey = "myKey";
+        fooProp.myKey = "myKey";
+
+        fooField.myRev = "myRev";
+        fooProp.myRev = "myRev";
+
+        fooField.myFrom = "myFrom";
+        fooProp.myFrom = "myFrom";
+
+        fooField.myTo = "myTo";
+        fooProp.myTo = "myTo";
+    }
+
     @Test
-    void serialize() {
-        Foo foo = new Foo("foo", "bar");
-        ObjectNode node = mapper.convertValue(foo, ObjectNode.class);
-//        assertThat(node.get("myId").textValue()).isEqualTo("foo");
-        assertThat(node.get("myKey").textValue()).isEqualTo("bar");
+    void serializeField() {
+        // id
+        testSerialize(fooField, "myId", fooField.myId, this::jacksonSerialize);
+        testSerialize(fooField, "_id", fooField.myId, this::serdeSerialize);
+        // key
+        testSerialize(fooField, "myKey", fooField.myKey, this::jacksonSerialize);
+        testSerialize(fooField, "_key", fooField.myKey, this::serdeSerialize);
+        // rev
+        testSerialize(fooField, "myRev", fooField.myRev, this::jacksonSerialize);
+        testSerialize(fooField, "_rev", fooField.myRev, this::serdeSerialize);
+        // from
+        testSerialize(fooField, "myFrom", fooField.myFrom, this::jacksonSerialize);
+        testSerialize(fooField, "_from", fooField.myFrom, this::serdeSerialize);
+        // to
+        testSerialize(fooField, "myTo", fooField.myTo, this::jacksonSerialize);
+        testSerialize(fooField, "_to", fooField.myTo, this::serdeSerialize);
+    }
+
+    @Test
+    void serializeProp() {
+        // id
+        testSerialize(fooProp, "myId", fooProp.myId, this::jacksonSerialize);
+        testSerialize(fooProp, "_id", fooProp.myId, this::serdeSerialize);
+        // key
+        testSerialize(fooProp, "myKey", fooProp.myKey, this::jacksonSerialize);
+        testSerialize(fooProp, "_key", fooProp.myKey, this::serdeSerialize);
+        // rev
+        testSerialize(fooProp, "myRev", fooProp.myRev, this::jacksonSerialize);
+        testSerialize(fooProp, "_rev", fooProp.myRev, this::serdeSerialize);
+        // from
+        testSerialize(fooProp, "myFrom", fooProp.myFrom, this::jacksonSerialize);
+        testSerialize(fooProp, "_from", fooProp.myFrom, this::serdeSerialize);
+        // to
+        testSerialize(fooProp, "myTo", fooProp.myTo, this::jacksonSerialize);
+        testSerialize(fooProp, "_to", fooProp.myTo, this::serdeSerialize);
+    }
+
+    @Test
+    void deserializeField() throws IOException {
+        // id
+        testDeserialize("myId", FooField.class, foo -> foo.myId, this::jacksonDeserialize);
+        testDeserialize("_id", FooField.class, foo -> foo.myId, this::serdeDeserialize);
+        // key
+        testDeserialize("myKey", FooField.class, foo -> foo.myKey, this::jacksonDeserialize);
+        testDeserialize("_key", FooField.class, foo -> foo.myKey, this::serdeDeserialize);
+        // rev
+        testDeserialize("myRev", FooField.class, foo -> foo.myRev, this::jacksonDeserialize);
+        testDeserialize("_rev", FooField.class, foo -> foo.myRev, this::serdeDeserialize);
+        // from
+        testDeserialize("myFrom", FooField.class, foo -> foo.myFrom, this::jacksonDeserialize);
+        testDeserialize("_from", FooField.class, foo -> foo.myFrom, this::serdeDeserialize);
+        // to
+        testDeserialize("myTo", FooField.class, foo -> foo.myTo, this::jacksonDeserialize);
+        testDeserialize("_to", FooField.class, foo -> foo.myTo, this::serdeDeserialize);
+    }
+
+    @Test
+    void deserializeProp() throws IOException {
+        // id
+        testDeserialize("myId", FooProp.class, FooProp::getMyId, this::jacksonDeserialize);
+        testDeserialize("_id", FooProp.class, FooProp::getMyId, this::serdeDeserialize);
+        // key
+        testDeserialize("myKey", FooProp.class, FooProp::getMyKey, this::jacksonDeserialize);
+        testDeserialize("_key", FooProp.class, FooProp::getMyKey, this::serdeDeserialize);
+        // rev
+        testDeserialize("myRev", FooProp.class, FooProp::getMyRev, this::jacksonDeserialize);
+        testDeserialize("_rev", FooProp.class, FooProp::getMyRev, this::serdeDeserialize);
+        // from
+        testDeserialize("myFrom", FooProp.class, FooProp::getMyFrom, this::jacksonDeserialize);
+        testDeserialize("_from", FooProp.class, FooProp::getMyFrom, this::serdeDeserialize);
+        // to
+        testDeserialize("myTo", FooProp.class, FooProp::getMyTo, this::jacksonDeserialize);
+        testDeserialize("_to", FooProp.class, FooProp::getMyTo, this::serdeDeserialize);
+    }
+
+    void testSerialize(Object data, String fieldName, String expectedValue, Function<Object, JsonNode> serializer) {
+        JsonNode jn = serializer.apply(data).get(fieldName);
+        assertThat(jn).isNotNull();
+        assertThat(jn.textValue()).isEqualTo(expectedValue);
+    }
+
+    <T> void testDeserialize(String fieldName, Class<T> clazz, Function<T, String> getter,
+                             BiFunction<byte[], Class<T>, T> deserializer) throws IOException {
+        String fieldValue = UUID.randomUUID().toString();
+        ObjectNode on = JsonNodeFactory.instance.objectNode().put(fieldName, fieldValue);
+        byte[] bytes = mapper.writeValueAsBytes(on);
+        T deser = deserializer.apply(bytes, clazz);
+        assertThat(getter.apply(deser)).isEqualTo(fieldValue);
+    }
+
+    private JsonNode jacksonSerialize(Object data) {
+        try {
+            return mapper.readTree(mapper.writeValueAsBytes(data));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private JsonNode serdeSerialize(Object data) {
+        try {
+            return mapper.readTree(serde.serialize(data));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T> T jacksonDeserialize(byte[] bytes, Class<T> clazz) {
+        try {
+            return mapper.readValue(bytes, clazz);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T> T serdeDeserialize(byte[] bytes, Class<T> clazz) {
+        return serde.deserialize(bytes, clazz);
     }
 }

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/From.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/From.java
@@ -1,9 +1,5 @@
 package com.arangodb.serde.jackson;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +10,5 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-@JacksonAnnotationsInside
-@JsonProperty("_from")
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public @interface From {
 }

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/Id.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/Id.java
@@ -1,9 +1,5 @@
 package com.arangodb.serde.jackson;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +10,5 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-@JacksonAnnotationsInside
-@JsonProperty("_id")
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public @interface Id {
 }

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/Key.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/Key.java
@@ -1,9 +1,5 @@
 package com.arangodb.serde.jackson;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +10,5 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-@JacksonAnnotationsInside
-@JsonProperty("_key")
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public @interface Key {
 }

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/Rev.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/Rev.java
@@ -1,9 +1,5 @@
 package com.arangodb.serde.jackson;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +10,5 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-@JacksonAnnotationsInside
-@JsonProperty("_rev")
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public @interface Rev {
 }

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/To.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/To.java
@@ -1,9 +1,5 @@
 package com.arangodb.serde.jackson;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +10,5 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-@JacksonAnnotationsInside
-@JsonProperty("_to")
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public @interface To {
 }

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/ArangoSerdeAnnotationIntrospector.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/ArangoSerdeAnnotationIntrospector.java
@@ -1,0 +1,44 @@
+package com.arangodb.serde.jackson.internal;
+
+import com.arangodb.serde.jackson.Key;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+
+class ArangoSerdeAnnotationIntrospector extends JacksonAnnotationIntrospector {
+    private static final JsonInclude JSON_INCLUDE_NON_NULL = JsonIncludeNonNull.class.getAnnotation(JsonInclude.class);
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private static class JsonIncludeNonNull {
+    }
+
+    @Override
+    public PropertyName findNameForSerialization(Annotated a) {
+        Key kann = _findAnnotation(a, Key.class);
+        if (kann != null) {
+            return PropertyName.construct("_key");
+        }
+        return super.findNameForSerialization(a);
+    }
+
+    @Override
+    public PropertyName findNameForDeserialization(Annotated a) {
+        Key kann = _findAnnotation(a, Key.class);
+        if (kann != null) {
+            return PropertyName.construct("_key");
+        } else {
+            return super.findNameForDeserialization(a);
+        }
+    }
+
+    @Override
+    public JsonInclude.Value findPropertyInclusion(Annotated a) {
+        Key kann = _findAnnotation(a, Key.class);
+        if (kann != null) {
+            return new JsonInclude.Value(JSON_INCLUDE_NON_NULL);
+        } else {
+            return super.findPropertyInclusion(a);
+        }
+    }
+}

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/ArangoSerdeAnnotationIntrospector.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/ArangoSerdeAnnotationIntrospector.java
@@ -1,13 +1,30 @@
 package com.arangodb.serde.jackson.internal;
 
-import com.arangodb.serde.jackson.Key;
+import com.arangodb.serde.jackson.*;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 class ArangoSerdeAnnotationIntrospector extends JacksonAnnotationIntrospector {
     private static final JsonInclude JSON_INCLUDE_NON_NULL = JsonIncludeNonNull.class.getAnnotation(JsonInclude.class);
+    private static final Map<Class<? extends Annotation>, String> MAPPINGS;
+    private static final Class<? extends Annotation>[] ANNOTATIONS;
+
+    static {
+        MAPPINGS = new HashMap<>();
+        MAPPINGS.put(Id.class, "_id");
+        MAPPINGS.put(Key.class, "_key");
+        MAPPINGS.put(Rev.class, "_rev");
+        MAPPINGS.put(From.class, "_from");
+        MAPPINGS.put(To.class, "_to");
+        ANNOTATIONS = MAPPINGS.keySet().toArray(new Class[0]);
+    }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private static class JsonIncludeNonNull {
@@ -15,27 +32,26 @@ class ArangoSerdeAnnotationIntrospector extends JacksonAnnotationIntrospector {
 
     @Override
     public PropertyName findNameForSerialization(Annotated a) {
-        Key kann = _findAnnotation(a, Key.class);
-        if (kann != null) {
-            return PropertyName.construct("_key");
-        }
-        return super.findNameForSerialization(a);
+        return Optional.ofNullable(findMapping(a)).orElseGet(() -> super.findNameForSerialization(a));
     }
 
     @Override
     public PropertyName findNameForDeserialization(Annotated a) {
-        Key kann = _findAnnotation(a, Key.class);
-        if (kann != null) {
-            return PropertyName.construct("_key");
-        } else {
-            return super.findNameForDeserialization(a);
+        return Optional.ofNullable(findMapping(a)).orElseGet(() -> super.findNameForDeserialization(a));
+    }
+
+    private PropertyName findMapping(Annotated a) {
+        for (Map.Entry<Class<? extends Annotation>, String> e : MAPPINGS.entrySet()) {
+            if (_hasAnnotation(a, e.getKey())) {
+                return PropertyName.construct(e.getValue());
+            }
         }
+        return null;
     }
 
     @Override
     public JsonInclude.Value findPropertyInclusion(Annotated a) {
-        Key kann = _findAnnotation(a, Key.class);
-        if (kann != null) {
+        if (_hasOneOf(a, ANNOTATIONS)) {
             return new JsonInclude.Value(JSON_INCLUDE_NON_NULL);
         } else {
             return super.findPropertyInclusion(a);

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/JacksonSerdeImpl.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/JacksonSerdeImpl.java
@@ -18,6 +18,7 @@ public final class JacksonSerdeImpl implements JacksonSerde {
     public JacksonSerdeImpl(final ObjectMapper mapper) {
         this.mapper = mapper;
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.setAnnotationIntrospector(new ArangoSerdeAnnotationIntrospector());
     }
 
     @Override


### PR DESCRIPTION
This PR aims to remove all usages of `@JacksonAnnotationsInside` annotations from serde annotation. The equivalent behavior should be implemented by extending `JacksonAnnotationIntrospector` in both Jackson Serde and Internal Serde. 
In this way ArangoDB serde annotations will not be processed by other Jackson instances used in the application.

---
fixes #512 

