### PR TITLE
[DE-771] transaction aware deserializer

### DIFF
--- a/core/src/main/java/com/arangodb/internal/ArangoExecutor.java
+++ b/core/src/main/java/com/arangodb/internal/ArangoExecutor.java
@@ -25,6 +25,7 @@ import com.arangodb.QueueTimeMetrics;
 import com.arangodb.internal.config.ArangoConfig;
 import com.arangodb.internal.net.CommunicationProtocol;
 import com.arangodb.internal.serde.InternalSerde;
+import com.arangodb.serde.SerdeContext;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -58,8 +59,8 @@ public abstract class ArangoExecutor {
         protocol.setJwt(jwt);
     }
 
-    protected <T> T createResult(final Type type, final InternalResponse response) {
-        return serde.deserialize(response.getBody(), type);
+    protected <T> T createResult(final Type type, final InternalResponse response, final SerdeContext ctx) {
+        return serde.deserialize(response.getBody(), type, ctx);
     }
 
     protected final void interceptResponse(InternalResponse response) {
@@ -79,6 +80,6 @@ public abstract class ArangoExecutor {
     }
 
     public interface ResponseDeserializer<T> {
-        T deserialize(InternalResponse response);
+        T deserialize(InternalResponse response, SerdeContext ctx);
     }
 }

--- a/core/src/main/java/com/arangodb/internal/ArangoExecutorSync.java
+++ b/core/src/main/java/com/arangodb/internal/ArangoExecutorSync.java
@@ -23,6 +23,7 @@ package com.arangodb.internal;
 import com.arangodb.internal.config.ArangoConfig;
 import com.arangodb.internal.net.CommunicationProtocol;
 import com.arangodb.internal.net.HostHandle;
+import com.arangodb.internal.serde.SerdeUtils;
 
 import java.lang.reflect.Type;
 
@@ -40,7 +41,7 @@ public class ArangoExecutorSync extends ArangoExecutor {
     }
 
     public <T> T execute(final InternalRequest request, final Type type, final HostHandle hostHandle) {
-        return execute(request, response -> createResult(type, response), hostHandle);
+        return execute(request, (response, ctx) -> createResult(type, response, ctx), hostHandle);
     }
 
     public <T> T execute(final InternalRequest request, final ResponseDeserializer<T> responseDeserializer) {
@@ -54,7 +55,7 @@ public class ArangoExecutorSync extends ArangoExecutor {
 
         final InternalResponse response = protocol.execute(interceptRequest(request), hostHandle);
         interceptResponse(response);
-        return responseDeserializer.deserialize(response);
+        return responseDeserializer.deserialize(response, SerdeUtils.createSerdeContext(request));
     }
 
 }

--- a/core/src/main/java/com/arangodb/internal/InternalArangoCollection.java
+++ b/core/src/main/java/com/arangodb/internal/InternalArangoCollection.java
@@ -110,7 +110,7 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
     }
 
     protected <T> ResponseDeserializer<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocumentsResponseDeserializer(Class<T> userDataClass) {
-        return response -> {
+        return (response, ctx) -> {
             final MultiDocumentEntity<DocumentCreateEntity<T>> multiDocument = new MultiDocumentEntity<>();
             final List<DocumentCreateEntity<T>> docs = new ArrayList<>();
             final List<ErrorEntity> errors = new ArrayList<>();
@@ -119,12 +119,12 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
             for (final JsonNode next : body) {
                 JsonNode isError = next.get(ArangoResponseField.ERROR_FIELD_NAME);
                 if (isError != null && isError.booleanValue()) {
-                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class);
+                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class, ctx);
                     errors.add(error);
                     documentsAndErrors.add(error);
                 } else {
                     Type type = constructParametricType(DocumentCreateEntity.class, userDataClass);
-                    final DocumentCreateEntity<T> doc = getSerde().deserialize(next, type);
+                    final DocumentCreateEntity<T> doc = getSerde().deserialize(next, type, ctx);
                     docs.add(doc);
                     documentsAndErrors.add(doc);
                 }
@@ -168,7 +168,7 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
     }
 
     protected <T> ResponseDeserializer<T> getDocumentResponseDeserializer(final Class<T> type) {
-        return response -> getSerde().deserializeUserData(response.getBody(), type);
+        return (response, ctx) -> getSerde().deserializeUserData(response.getBody(), type, ctx);
     }
 
     protected InternalRequest getDocumentsRequest(final Iterable<String> keys, final DocumentReadOptions options) {
@@ -186,7 +186,7 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
 
     protected <T> ResponseDeserializer<MultiDocumentEntity<T>> getDocumentsResponseDeserializer(
             final Class<T> type) {
-        return response -> {
+        return (response, ctx) -> {
             final MultiDocumentEntity<T> multiDocument = new MultiDocumentEntity<>();
             boolean potentialDirtyRead = Boolean.parseBoolean(response.getMeta("X-Arango-Potential-Dirty-Read"));
             multiDocument.setPotentialDirtyRead(potentialDirtyRead);
@@ -197,11 +197,11 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
             for (final JsonNode next : body) {
                 JsonNode isError = next.get(ArangoResponseField.ERROR_FIELD_NAME);
                 if (isError != null && isError.booleanValue()) {
-                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class);
+                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class, ctx);
                     errors.add(error);
                     documentsAndErrors.add(error);
                 } else {
-                    final T doc = getSerde().deserializeUserData(getSerde().serialize(next), type);
+                    final T doc = getSerde().deserializeUserData(getSerde().serialize(next), type, ctx);
                     docs.add(doc);
                     documentsAndErrors.add(doc);
                 }
@@ -249,7 +249,7 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
 
     protected <T> ResponseDeserializer<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocumentsResponseDeserializer(
             final Class<T> returnType) {
-        return response -> {
+        return (response, ctx) -> {
             final MultiDocumentEntity<DocumentUpdateEntity<T>> multiDocument = new MultiDocumentEntity<>();
             final List<DocumentUpdateEntity<T>> docs = new ArrayList<>();
             final List<ErrorEntity> errors = new ArrayList<>();
@@ -258,12 +258,12 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
             for (final JsonNode next : body) {
                 JsonNode isError = next.get(ArangoResponseField.ERROR_FIELD_NAME);
                 if (isError != null && isError.booleanValue()) {
-                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class);
+                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class, ctx);
                     errors.add(error);
                     documentsAndErrors.add(error);
                 } else {
                     Type type = constructParametricType(DocumentUpdateEntity.class, returnType);
-                    final DocumentUpdateEntity<T> doc = getSerde().deserialize(next, type);
+                    final DocumentUpdateEntity<T> doc = getSerde().deserialize(next, type, ctx);
                     docs.add(doc);
                     documentsAndErrors.add(doc);
                 }
@@ -312,7 +312,7 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
 
     protected <T> ResponseDeserializer<MultiDocumentEntity<DocumentUpdateEntity<T>>> updateDocumentsResponseDeserializer(
             final Class<T> returnType) {
-        return response -> {
+        return (response, ctx) -> {
             final MultiDocumentEntity<DocumentUpdateEntity<T>> multiDocument = new MultiDocumentEntity<>();
             final List<DocumentUpdateEntity<T>> docs = new ArrayList<>();
             final List<ErrorEntity> errors = new ArrayList<>();
@@ -321,12 +321,12 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
             for (final JsonNode next : body) {
                 JsonNode isError = next.get(ArangoResponseField.ERROR_FIELD_NAME);
                 if (isError != null && isError.booleanValue()) {
-                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class);
+                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class, ctx);
                     errors.add(error);
                     documentsAndErrors.add(error);
                 } else {
                     Type type = constructParametricType(DocumentUpdateEntity.class, returnType);
-                    final DocumentUpdateEntity<T> doc = getSerde().deserialize(next, type);
+                    final DocumentUpdateEntity<T> doc = getSerde().deserialize(next, type, ctx);
                     docs.add(doc);
                     documentsAndErrors.add(doc);
                 }
@@ -368,7 +368,7 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
 
     protected <T> ResponseDeserializer<MultiDocumentEntity<DocumentDeleteEntity<T>>> deleteDocumentsResponseDeserializer(
             final Class<T> userDataClass) {
-        return response -> {
+        return (response, ctx) -> {
             final MultiDocumentEntity<DocumentDeleteEntity<T>> multiDocument = new MultiDocumentEntity<>();
             final List<DocumentDeleteEntity<T>> docs = new ArrayList<>();
             final List<ErrorEntity> errors = new ArrayList<>();
@@ -377,12 +377,12 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
             for (final JsonNode next : body) {
                 JsonNode isError = next.get(ArangoResponseField.ERROR_FIELD_NAME);
                 if (isError != null && isError.booleanValue()) {
-                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class);
+                    final ErrorEntity error = getSerde().deserialize(next, ErrorEntity.class, ctx);
                     errors.add(error);
                     documentsAndErrors.add(error);
                 } else {
                     Type type = constructParametricType(DocumentDeleteEntity.class, userDataClass);
-                    final DocumentDeleteEntity<T> doc = getSerde().deserialize(next, type);
+                    final DocumentDeleteEntity<T> doc = getSerde().deserialize(next, type, ctx);
                     docs.add(doc);
                     documentsAndErrors.add(doc);
                 }
@@ -413,7 +413,7 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<String> deleteIndexResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/id", String.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/id", String.class, ctx);
     }
 
     private String createIndexId(final String id) {
@@ -495,11 +495,11 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<IndexEntity>> getIndexesResponseDeserializer() {
-        return response -> {
+        return (response, ctx) -> {
             Collection<IndexEntity> indexes = new ArrayList<>();
             for (JsonNode idx : getSerde().parse(response.getBody(), "/indexes")) {
                 if (!"inverted".equals(idx.get("type").textValue())) {
-                    indexes.add(getSerde().deserialize(idx, IndexEntity.class));
+                    indexes.add(getSerde().deserialize(idx, IndexEntity.class, ctx));
                 }
             }
             return indexes;
@@ -507,11 +507,11 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<InvertedIndexEntity>> getInvertedIndexesResponseDeserializer() {
-        return response -> {
+        return (response, ctx) -> {
             Collection<InvertedIndexEntity> indexes = new ArrayList<>();
             for (JsonNode idx : getSerde().parse(response.getBody(), "/indexes")) {
                 if ("inverted".equals(idx.get("type").textValue())) {
-                    indexes.add(getSerde().deserialize(idx, InvertedIndexEntity.class));
+                    indexes.add(getSerde().deserialize(idx, InvertedIndexEntity.class, ctx));
                 }
             }
             return indexes;
@@ -583,8 +583,8 @@ public abstract class InternalArangoCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Permissions> getPermissionsResponseDeserialzer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                Permissions.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                Permissions.class, ctx);
     }
 
 }

--- a/core/src/main/java/com/arangodb/internal/InternalArangoDB.java
+++ b/core/src/main/java/com/arangodb/internal/InternalArangoDB.java
@@ -66,11 +66,11 @@ public abstract class InternalArangoDB extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<ServerRole> getRoleResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/role", ServerRole.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/role", ServerRole.class, ctx);
     }
 
     protected ResponseDeserializer<String> getServerIdResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/id", String.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/id", String.class, ctx);
     }
 
     protected InternalRequest createDatabaseRequest(final DBCreateOptions options) {
@@ -81,8 +81,8 @@ public abstract class InternalArangoDB extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Boolean> createDatabaseResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                Boolean.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                Boolean.class, ctx);
     }
 
     protected InternalRequest getDatabasesRequest(final String dbName) {
@@ -90,8 +90,8 @@ public abstract class InternalArangoDB extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<String>> getDatabaseResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                constructListType(String.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                constructListType(String.class), ctx);
     }
 
     protected InternalRequest getAccessibleDatabasesForRequest(final String dbName, final String user) {
@@ -99,7 +99,7 @@ public abstract class InternalArangoDB extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<String>> getAccessibleDatabasesForResponseDeserializer() {
-        return response -> {
+        return (response, ctx) -> {
             Iterator<String> names =
                     getSerde().parse(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER).fieldNames();
             final Collection<String> dbs = new ArrayList<>();
@@ -136,8 +136,8 @@ public abstract class InternalArangoDB extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<UserEntity>> getUsersResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                constructListType(UserEntity.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                constructListType(UserEntity.class), ctx);
     }
 
     protected InternalRequest updateUserRequest(final String dbName, final String user, final UserUpdateOptions options) {
@@ -173,10 +173,10 @@ public abstract class InternalArangoDB extends ArangoExecuteable {
     }
 
     protected <T> ResponseDeserializer<Response<T>> responseDeserializer(Class<T> type) {
-        return response -> new Response<>(
+        return (response, ctx) -> new Response<>(
                 response.getResponseCode(),
                 response.getMeta(),
-                getSerde().deserializeUserData(response.getBody(), type)
+                getSerde().deserializeUserData(response.getBody(), type, ctx)
         );
     }
 

--- a/core/src/main/java/com/arangodb/internal/InternalArangoDatabase.java
+++ b/core/src/main/java/com/arangodb/internal/InternalArangoDatabase.java
@@ -70,8 +70,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<String>> getDatabaseResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                constructListType(String.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                constructListType(String.class), ctx);
     }
 
     protected InternalRequest getAccessibleDatabasesRequest() {
@@ -103,8 +103,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<CollectionEntity>> getCollectionsResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                constructListType(CollectionEntity.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                constructListType(CollectionEntity.class), ctx);
     }
 
     protected InternalRequest dropRequest() {
@@ -112,8 +112,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Boolean> createDropResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                Boolean.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                Boolean.class, ctx);
     }
 
     protected InternalRequest grantAccessRequest(final String user, final Permissions permissions) {
@@ -136,8 +136,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Permissions> getPermissionsResponseDeserialzer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                Permissions.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                Permissions.class, ctx);
     }
 
     protected InternalRequest queryRequest(final String query, final Map<String, Object> bindVars,
@@ -232,8 +232,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     public <T> ResponseDeserializer<CursorEntity<T>> cursorEntityDeserializer(final Class<T> type) {
-        return response -> {
-            CursorEntity<T> e = getSerde().deserialize(response.getBody(), constructParametricType(CursorEntity.class, type));
+        return (response, ctx) -> {
+            CursorEntity<T> e = getSerde().deserialize(response.getBody(), constructParametricType(CursorEntity.class, type), ctx);
             boolean potentialDirtyRead = Boolean.parseBoolean(response.getMeta("X-Arango-Potential-Dirty-Read"));
             e.setPotentialDirtyRead(potentialDirtyRead);
             return e;
@@ -241,7 +241,7 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Integer> deleteAqlFunctionResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/deletedCount", Integer.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/deletedCount", Integer.class, ctx);
     }
 
     protected InternalRequest getAqlFunctionsRequest(final AqlFunctionGetOptions options) {
@@ -252,8 +252,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<AqlFunctionEntity>> getAqlFunctionsResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                constructListType(AqlFunctionEntity.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                constructListType(AqlFunctionEntity.class), ctx);
     }
 
     protected InternalRequest createGraphRequest(final String name, final Iterable<EdgeDefinition> edgeDefinitions,
@@ -265,7 +265,7 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<GraphEntity> createGraphResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/graph", GraphEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/graph", GraphEntity.class, ctx);
     }
 
     protected InternalRequest getGraphsRequest() {
@@ -273,8 +273,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<GraphEntity>> getGraphsResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/graphs",
-                constructListType(GraphEntity.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/graphs",
+                constructListType(GraphEntity.class), ctx);
     }
 
     protected InternalRequest transactionRequest(final String action, final TransactionOptions options) {
@@ -282,9 +282,9 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected <T> ResponseDeserializer<T> transactionResponseDeserializer(final Class<T> type) {
-        return response -> {
+        return (response, ctx) -> {
             byte[] userContent = getSerde().extract(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER);
-            return getSerde().deserializeUserData(userContent, type);
+            return getSerde().deserializeUserData(userContent, type, ctx);
         };
     }
 
@@ -310,8 +310,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<TransactionEntity>> transactionsResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/transactions",
-                constructListType(TransactionEntity.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/transactions",
+                constructListType(TransactionEntity.class), ctx);
     }
 
     protected InternalRequest commitStreamTransactionRequest(String id) {
@@ -319,8 +319,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<StreamTransactionEntity> streamTransactionResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                StreamTransactionEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                StreamTransactionEntity.class, ctx);
     }
 
     protected InternalRequest getInfoRequest() {
@@ -328,8 +328,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<DatabaseEntity> getInfoResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                DatabaseEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                DatabaseEntity.class, ctx);
     }
 
     protected InternalRequest reloadRoutingRequest() {
@@ -341,8 +341,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<ViewEntity>> getViewsResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                constructListType(ViewEntity.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                constructListType(ViewEntity.class), ctx);
     }
 
     protected InternalRequest createViewRequest(final String name, final ViewType type) {
@@ -367,8 +367,8 @@ public abstract class InternalArangoDatabase extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<SearchAnalyzer>> getSearchAnalyzersResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
-                constructListType(SearchAnalyzer.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), ArangoResponseField.RESULT_JSON_POINTER,
+                constructListType(SearchAnalyzer.class), ctx);
     }
 
     protected InternalRequest createAnalyzerRequest(final SearchAnalyzer options) {

--- a/core/src/main/java/com/arangodb/internal/InternalArangoEdgeCollection.java
+++ b/core/src/main/java/com/arangodb/internal/InternalArangoEdgeCollection.java
@@ -79,7 +79,7 @@ public abstract class InternalArangoEdgeCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<EdgeEntity> insertEdgeResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), EDGE_JSON_POINTER, EdgeEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), EDGE_JSON_POINTER, EdgeEntity.class, ctx);
     }
 
     protected InternalRequest getEdgeRequest(final String key, final GraphDocumentReadOptions options) {
@@ -96,7 +96,7 @@ public abstract class InternalArangoEdgeCollection extends ArangoExecuteable {
     }
 
     protected <T> ResponseDeserializer<T> getEdgeResponseDeserializer(final Class<T> type) {
-        return response -> getSerde().deserializeUserData(getSerde().extract(response.getBody(), EDGE_JSON_POINTER), type);
+        return (response, ctx) -> getSerde().deserializeUserData(getSerde().extract(response.getBody(), EDGE_JSON_POINTER), type, ctx);
     }
 
     protected <T> InternalRequest replaceEdgeRequest(final String key, final T value, final EdgeReplaceOptions options) {
@@ -111,7 +111,7 @@ public abstract class InternalArangoEdgeCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<EdgeUpdateEntity> replaceEdgeResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), EDGE_JSON_POINTER, EdgeUpdateEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), EDGE_JSON_POINTER, EdgeUpdateEntity.class, ctx);
     }
 
     protected <T> InternalRequest updateEdgeRequest(final String key, final T value, final EdgeUpdateOptions options) {
@@ -128,7 +128,7 @@ public abstract class InternalArangoEdgeCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<EdgeUpdateEntity> updateEdgeResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), EDGE_JSON_POINTER, EdgeUpdateEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), EDGE_JSON_POINTER, EdgeUpdateEntity.class, ctx);
     }
 
     protected InternalRequest deleteEdgeRequest(final String key, final EdgeDeleteOptions options) {

--- a/core/src/main/java/com/arangodb/internal/InternalArangoGraph.java
+++ b/core/src/main/java/com/arangodb/internal/InternalArangoGraph.java
@@ -79,8 +79,8 @@ public abstract class InternalArangoGraph extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<String>> getVertexCollectionsResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/collections",
-                constructListType(String.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/collections",
+                constructListType(String.class), ctx);
     }
 
     protected InternalRequest addVertexCollectionRequest(final String name, final VertexCollectionCreateOptions options) {
@@ -98,8 +98,8 @@ public abstract class InternalArangoGraph extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<Collection<String>> getEdgeDefinitionsDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), "/collections",
-                constructListType(String.class));
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), "/collections",
+                constructListType(String.class), ctx);
     }
 
     protected InternalRequest addEdgeDefinitionRequest(final EdgeDefinition definition) {
@@ -109,7 +109,7 @@ public abstract class InternalArangoGraph extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<GraphEntity> addEdgeDefinitionResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), GRAPH, GraphEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), GRAPH, GraphEntity.class, ctx);
     }
 
     protected InternalRequest replaceEdgeDefinitionRequest(final EdgeDefinition definition, final ReplaceEdgeDefinitionOptions options) {
@@ -122,7 +122,7 @@ public abstract class InternalArangoGraph extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<GraphEntity> replaceEdgeDefinitionResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), GRAPH, GraphEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), GRAPH, GraphEntity.class, ctx);
     }
 
 }

--- a/core/src/main/java/com/arangodb/internal/InternalArangoVertexCollection.java
+++ b/core/src/main/java/com/arangodb/internal/InternalArangoVertexCollection.java
@@ -77,7 +77,7 @@ public abstract class InternalArangoVertexCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<VertexEntity> insertVertexResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), VERTEX_JSON_POINTER, VertexEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), VERTEX_JSON_POINTER, VertexEntity.class, ctx);
     }
 
     protected InternalRequest getVertexRequest(final String key, final GraphDocumentReadOptions options) {
@@ -94,7 +94,7 @@ public abstract class InternalArangoVertexCollection extends ArangoExecuteable {
     }
 
     protected <T> ResponseDeserializer<T> getVertexResponseDeserializer(final Class<T> type) {
-        return response -> getSerde().deserializeUserData(getSerde().extract(response.getBody(), VERTEX_JSON_POINTER), type);
+        return (response, ctx) -> getSerde().deserializeUserData(getSerde().extract(response.getBody(), VERTEX_JSON_POINTER), type, ctx);
     }
 
     protected <T> InternalRequest replaceVertexRequest(final String key, final T value, final VertexReplaceOptions options) {
@@ -109,7 +109,7 @@ public abstract class InternalArangoVertexCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<VertexUpdateEntity> replaceVertexResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), VERTEX_JSON_POINTER, VertexUpdateEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), VERTEX_JSON_POINTER, VertexUpdateEntity.class, ctx);
     }
 
     protected <T> InternalRequest updateVertexRequest(final String key, final T value, final VertexUpdateOptions options) {
@@ -126,7 +126,7 @@ public abstract class InternalArangoVertexCollection extends ArangoExecuteable {
     }
 
     protected ResponseDeserializer<VertexUpdateEntity> updateVertexResponseDeserializer() {
-        return response -> getSerde().deserialize(response.getBody(), VERTEX_JSON_POINTER, VertexUpdateEntity.class);
+        return (response, ctx) -> getSerde().deserialize(response.getBody(), VERTEX_JSON_POINTER, VertexUpdateEntity.class, ctx);
     }
 
     protected InternalRequest deleteVertexRequest(final String key, final VertexDeleteOptions options) {

--- a/core/src/main/java/com/arangodb/internal/net/ExtendedHostResolver.java
+++ b/core/src/main/java/com/arangodb/internal/net/ExtendedHostResolver.java
@@ -133,11 +133,11 @@ public class ExtendedHostResolver implements HostResolver {
         try {
             response = executor.execute(
                     new InternalRequest(ArangoRequestParam.SYSTEM, RequestType.GET, "/_api/cluster/endpoints"),
-                    response1 -> {
-                        final List<Map<String, String>> tmp = arangoSerialization.deserialize(response1.getBody(),
+                    (r, ctx) -> {
+                        final List<Map<String, String>> tmp = arangoSerialization.deserialize(r.getBody(),
                                 "/endpoints",
                                 constructParametricType(List.class,
-                                        constructParametricType(Map.class, String.class, String.class)));
+                                        constructParametricType(Map.class, String.class, String.class)), ctx);
                         Collection<String> endpoints = new ArrayList<>();
                         for (final Map<String, String> map : tmp) {
                             endpoints.add(map.get("endpoint"));

--- a/core/src/main/java/com/arangodb/internal/serde/InternalSerde.java
+++ b/core/src/main/java/com/arangodb/internal/serde/InternalSerde.java
@@ -3,6 +3,7 @@ package com.arangodb.internal.serde;
 import com.arangodb.arch.UsedInApi;
 import com.arangodb.serde.ArangoSerde;
 import com.arangodb.ContentType;
+import com.arangodb.serde.SerdeContext;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.lang.reflect.Type;
@@ -34,19 +35,21 @@ public interface InternalSerde extends ArangoSerde {
      *
      * @param content byte array to deserialize
      * @param type    target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    <T> T deserialize(byte[] content, Type type);
+    <T> T deserialize(byte[] content, Type type, SerdeContext ctx);
 
     /**
      * Deserializes the parsed json node and binds it to the target data type.
      *
      * @param node  parsed json node
      * @param clazz class of target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    default <T> T deserialize(JsonNode node, Class<T> clazz) {
-        return deserialize(node, (Type) clazz);
+    default <T> T deserialize(JsonNode node, Class<T> clazz, SerdeContext ctx) {
+        return deserialize(node, (Type) clazz, ctx);
     }
 
     /**
@@ -54,9 +57,10 @@ public interface InternalSerde extends ArangoSerde {
      *
      * @param node parsed json node
      * @param type target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    <T> T deserialize(JsonNode node, Type type);
+    <T> T deserialize(JsonNode node, Type type, SerdeContext ctx);
 
     /**
      * Parses the content.
@@ -82,10 +86,11 @@ public interface InternalSerde extends ArangoSerde {
      * @param content     byte array to deserialize
      * @param jsonPointer location of data to be deserialized
      * @param clazz       class of target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    default <T> T deserialize(byte[] content, String jsonPointer, Class<T> clazz) {
-        return deserialize(content, jsonPointer, (Type) clazz);
+    default <T> T deserialize(byte[] content, String jsonPointer, Class<T> clazz, SerdeContext ctx) {
+        return deserialize(content, jsonPointer, (Type) clazz, ctx);
     }
 
     /**
@@ -95,10 +100,11 @@ public interface InternalSerde extends ArangoSerde {
      * @param content     byte array to deserialize
      * @param jsonPointer location of data to be deserialized
      * @param type        target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    default <T> T deserialize(byte[] content, String jsonPointer, Type type) {
-        return deserialize(parse(content, jsonPointer), type);
+    default <T> T deserialize(byte[] content, String jsonPointer, Type type, SerdeContext ctx) {
+        return deserialize(parse(content, jsonPointer), type, ctx);
     }
 
     /**
@@ -122,28 +128,31 @@ public interface InternalSerde extends ArangoSerde {
      *
      * @param content byte array to deserialize
      * @param clazz   class of target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    <T> T deserializeUserData(byte[] content, Class<T> clazz);
+    <T> T deserializeUserData(byte[] content, Class<T> clazz, SerdeContext ctx);
 
     /**
      * Deserializes the content and binds it to the target data type, using the user serde.
      *
      * @param content byte array to deserialize
      * @param type    target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    <T> T deserializeUserData(byte[] content, Type type);
+    <T> T deserializeUserData(byte[] content, Type type, SerdeContext ctx);
 
     /**
      * Deserializes the parsed json node and binds it to the target data type, using the user serde.
      *
      * @param node  parsed json node
      * @param clazz class of target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    default <T> T deserializeUserData(JsonNode node, Class<T> clazz) {
-        return deserializeUserData(node, (Type) clazz);
+    default <T> T deserializeUserData(JsonNode node, Class<T> clazz, SerdeContext ctx) {
+        return deserializeUserData(node, (Type) clazz, ctx);
     }
 
     /**
@@ -151,9 +160,10 @@ public interface InternalSerde extends ArangoSerde {
      *
      * @param node parsed json node
      * @param type target data type
+     * @param ctx     serde context
      * @return deserialized object
      */
-    <T> T deserializeUserData(JsonNode node, Type type);
+    <T> T deserializeUserData(JsonNode node, Type type, SerdeContext ctx);
 
     /**
      * @return the user serde

--- a/core/src/main/java/com/arangodb/internal/serde/InternalSerdeImpl.java
+++ b/core/src/main/java/com/arangodb/internal/serde/InternalSerdeImpl.java
@@ -4,6 +4,7 @@ import com.arangodb.ArangoDBException;
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.entity.BaseEdgeDocument;
 import com.arangodb.serde.ArangoSerde;
+import com.arangodb.serde.SerdeContext;
 import com.arangodb.util.RawBytes;
 import com.arangodb.util.RawJson;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -12,13 +13,16 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static com.arangodb.internal.serde.SerdeUtils.SERDE_CONTEXT_ATTRIBUTE_NAME;
 import static com.arangodb.internal.serde.SerdeUtils.checkSupportedJacksonVersion;
 
 final class InternalSerdeImpl implements InternalSerde {
@@ -57,7 +61,13 @@ final class InternalSerdeImpl implements InternalSerde {
 
     @Override
     public <T> T deserialize(byte[] content, Class<T> clazz) {
-        return deserialize(content, (Type) clazz);
+        throw new IllegalArgumentException("Deserialization without context should never be invoked.");
+    }
+
+    @Override
+    public <T> T deserialize(byte[] content, Class<T> clazz, SerdeContext ctx) {
+        Objects.requireNonNull(ctx);
+        return deserialize(content, (Type) clazz, ctx);
     }
 
     @Override
@@ -120,27 +130,27 @@ final class InternalSerdeImpl implements InternalSerde {
     }
 
     @Override
-    public <T> T deserializeUserData(byte[] content, Class<T> clazz) {
+    public <T> T deserializeUserData(byte[] content, Class<T> clazz, SerdeContext ctx) {
         if (isManagedClass(clazz)) {
-            return deserialize(content, clazz);
+            return deserialize(content, clazz, SerdeContextImpl.EMPTY);
         } else {
-            return userSerde.deserialize(content, clazz);
+            return userSerde.deserialize(content, clazz, ctx);
         }
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T deserializeUserData(byte[] content, Type type) {
+    public <T> T deserializeUserData(byte[] content, Type type, SerdeContext ctx) {
         if (type instanceof Class) {
-            return deserializeUserData(content, (Class<T>) type);
+            return deserializeUserData(content, (Class<T>) type, ctx);
         } else {
             throw new UnsupportedOperationException();
         }
     }
 
     @Override
-    public <T> T deserializeUserData(JsonNode node, Type type) {
-        return deserializeUserData(serialize(node), type);
+    public <T> T deserializeUserData(JsonNode node, Type type, SerdeContext ctx) {
+        return deserializeUserData(serialize(node), type, ctx);
     }
 
     @Override
@@ -149,21 +159,25 @@ final class InternalSerdeImpl implements InternalSerde {
     }
 
     @Override
-    public <T> T deserialize(final JsonNode node, final Type type) {
+    public <T> T deserialize(final JsonNode node, final Type type, final SerdeContext ctx) {
         try {
-            return mapper.readerFor(mapper.constructType(type)).readValue(node);
+            return mapper.readerFor(mapper.constructType(type))
+                    .with(ContextAttributes.getEmpty().withPerCallAttribute(SERDE_CONTEXT_ATTRIBUTE_NAME, ctx))
+                    .readValue(node);
         } catch (IOException e) {
             throw ArangoDBException.of(e);
         }
     }
 
     @Override
-    public <T> T deserialize(final byte[] content, final Type type) {
+    public <T> T deserialize(final byte[] content, final Type type, final SerdeContext ctx) {
         if (content == null) {
             return null;
         }
         try {
-            return mapper.readerFor(mapper.constructType(type)).readValue(content);
+            return mapper.readerFor(mapper.constructType(type))
+                    .with(ContextAttributes.getEmpty().withPerCallAttribute(SERDE_CONTEXT_ATTRIBUTE_NAME, ctx))
+                    .readValue(content);
         } catch (IOException e) {
             throw ArangoDBException.of(e);
         }

--- a/core/src/main/java/com/arangodb/internal/serde/SerdeContextImpl.java
+++ b/core/src/main/java/com/arangodb/internal/serde/SerdeContextImpl.java
@@ -1,0 +1,17 @@
+package com.arangodb.internal.serde;
+
+import com.arangodb.serde.SerdeContext;
+
+public class SerdeContextImpl implements SerdeContext {
+    public static final SerdeContext EMPTY = new SerdeContextImpl(null);
+    private final String streamTransactionId;
+
+    public SerdeContextImpl(String streamTransactionId) {
+        this.streamTransactionId = streamTransactionId;
+    }
+
+    @Override
+    public String getStreamTransactionId() {
+        return streamTransactionId;
+    }
+}

--- a/core/src/main/java/com/arangodb/internal/serde/SerdeUtils.java
+++ b/core/src/main/java/com/arangodb/internal/serde/SerdeUtils.java
@@ -1,6 +1,10 @@
 package com.arangodb.internal.serde;
 
 import com.arangodb.ArangoDBException;
+import com.arangodb.Request;
+import com.arangodb.internal.InternalRequest;
+import com.arangodb.model.TransactionalOptions;
+import com.arangodb.serde.SerdeContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -17,7 +21,9 @@ import java.util.List;
 public enum SerdeUtils {
     INSTANCE;
 
+    public static final String SERDE_CONTEXT_ATTRIBUTE_NAME = "arangoSerdeContext";
     private static final Logger LOGGER = LoggerFactory.getLogger(SerdeUtils.class);
+    private static final String TRANSACTION_ID = "x-arango-trx-id";
 
     private final ObjectMapper jsonMapper = new ObjectMapper();
 
@@ -53,6 +59,10 @@ public enum SerdeUtils {
                 LOGGER.warn("Unsupported Jackson version: {}", version);
             }
         });
+    }
+
+    public static SerdeContext createSerdeContext(InternalRequest request) {
+        return new SerdeContextImpl(request.getHeaderParam().get(TRANSACTION_ID));
     }
 
     /**

--- a/core/src/main/java/com/arangodb/internal/serde/UserDataDeserializer.java
+++ b/core/src/main/java/com/arangodb/internal/serde/UserDataDeserializer.java
@@ -1,5 +1,6 @@
 package com.arangodb.internal.serde;
 
+import com.arangodb.serde.SerdeContext;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -10,7 +11,9 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Objects;
 
+import static com.arangodb.internal.serde.SerdeUtils.SERDE_CONTEXT_ATTRIBUTE_NAME;
 import static com.arangodb.internal.serde.SerdeUtils.convertToType;
 
 class UserDataDeserializer extends JsonDeserializer<Object> implements ContextualDeserializer {
@@ -29,7 +32,9 @@ class UserDataDeserializer extends JsonDeserializer<Object> implements Contextua
 
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        return serde.deserializeUserData(p.readValueAsTree(), targetType);
+        SerdeContext serdeContext = (SerdeContext) ctxt.getAttribute(SERDE_CONTEXT_ATTRIBUTE_NAME);
+        Objects.requireNonNull(serdeContext);
+        return serde.deserializeUserData(p.readValueAsTree(), targetType, serdeContext);
     }
 
     @Override

--- a/core/src/main/java/com/arangodb/internal/util/ResponseUtils.java
+++ b/core/src/main/java/com/arangodb/internal/util/ResponseUtils.java
@@ -27,6 +27,7 @@ import com.arangodb.internal.net.ArangoDBRedirectException;
 import com.arangodb.internal.net.ArangoDBUnavailableException;
 import com.arangodb.internal.serde.InternalSerde;
 import com.arangodb.internal.InternalResponse;
+import com.arangodb.internal.serde.SerdeContextImpl;
 
 import java.util.concurrent.TimeoutException;
 
@@ -53,7 +54,7 @@ public final class ResponseUtils {
                     response.getMeta(HEADER_ENDPOINT));
         }
         if (response.getBody() != null) {
-            final ErrorEntity errorEntity = util.deserialize(response.getBody(), ErrorEntity.class);
+            final ErrorEntity errorEntity = util.deserialize(response.getBody(), ErrorEntity.class, SerdeContextImpl.EMPTY);
             if (errorEntity.getCode() == ERROR_INTERNAL && errorEntity.getErrorNum() == ERROR_INTERNAL) {
                 return ArangoDBUnavailableException.from(errorEntity);
             }

--- a/core/src/main/java/com/arangodb/model/AqlQueryOptions.java
+++ b/core/src/main/java/com/arangodb/model/AqlQueryOptions.java
@@ -28,7 +28,7 @@ import java.util.*;
  * @author Mark Vollmary
  * @author Michele Rastelli
  */
-public final class AqlQueryOptions implements Cloneable {
+public final class AqlQueryOptions extends TransactionalOptions<AqlQueryOptions> implements Cloneable {
 
     private Boolean count;
     private Integer ttl;
@@ -39,7 +39,11 @@ public final class AqlQueryOptions implements Cloneable {
     private String query;
     private Options options;
     private Boolean allowDirtyRead;
-    private String streamTransactionId;
+
+    @Override
+    AqlQueryOptions getThis() {
+        return this;
+    }
 
     public Boolean getCount() {
         return count;
@@ -467,20 +471,6 @@ public final class AqlQueryOptions implements Cloneable {
 
     public Boolean getAllowDirtyRead() {
         return allowDirtyRead;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public AqlQueryOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
-        return this;
     }
 
     public Boolean getAllowRetry() {

--- a/core/src/main/java/com/arangodb/model/CollectionCountOptions.java
+++ b/core/src/main/java/com/arangodb/model/CollectionCountOptions.java
@@ -23,25 +23,10 @@ package com.arangodb.model;
 /**
  * @author Michele Rastelli
  */
-public final class CollectionCountOptions {
+public final class CollectionCountOptions extends TransactionalOptions<CollectionCountOptions> {
 
-    private String streamTransactionId;
-
-    public CollectionCountOptions() {
-        super();
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public CollectionCountOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
+    @Override
+    CollectionCountOptions getThis() {
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/CollectionTruncateOptions.java
+++ b/core/src/main/java/com/arangodb/model/CollectionTruncateOptions.java
@@ -23,25 +23,10 @@ package com.arangodb.model;
 /**
  * @author Michele Rastelli
  */
-public final class CollectionTruncateOptions {
+public final class CollectionTruncateOptions extends TransactionalOptions<CollectionTruncateOptions> {
 
-    private String streamTransactionId;
-
-    public CollectionTruncateOptions() {
-        super();
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public CollectionTruncateOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
+    @Override
+    CollectionTruncateOptions getThis() {
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/DocumentCreateOptions.java
+++ b/core/src/main/java/com/arangodb/model/DocumentCreateOptions.java
@@ -24,21 +24,21 @@ package com.arangodb.model;
  * @author Mark Vollmary
  * @author Michele Rastelli
  */
-public final class DocumentCreateOptions {
+public final class DocumentCreateOptions extends TransactionalOptions<DocumentCreateOptions> {
 
     private Boolean waitForSync;
     private Boolean returnNew;
     private Boolean returnOld;
     private OverwriteMode overwriteMode;
     private Boolean silent;
-    private String streamTransactionId;
     private Boolean mergeObjects;
     private Boolean keepNull;
     private Boolean refillIndexCaches;
     private String versionAttribute;
 
-    public DocumentCreateOptions() {
-        super();
+    @Override
+    DocumentCreateOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -108,20 +108,6 @@ public final class DocumentCreateOptions {
      */
     public DocumentCreateOptions silent(final Boolean silent) {
         this.silent = silent;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public DocumentCreateOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/DocumentDeleteOptions.java
+++ b/core/src/main/java/com/arangodb/model/DocumentDeleteOptions.java
@@ -24,17 +24,17 @@ package com.arangodb.model;
  * @author Mark Vollmary
  * @author Michele Rastelli
  */
-public final class DocumentDeleteOptions {
+public final class DocumentDeleteOptions extends TransactionalOptions<DocumentDeleteOptions> {
 
     private Boolean waitForSync;
     private String ifMatch;
     private Boolean returnOld;
     private Boolean silent;
-    private String streamTransactionId;
     private Boolean refillIndexCaches;
 
-    public DocumentDeleteOptions() {
-        super();
+    @Override
+    DocumentDeleteOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -89,20 +89,6 @@ public final class DocumentDeleteOptions {
      */
     public DocumentDeleteOptions silent(final Boolean silent) {
         this.silent = silent;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public DocumentDeleteOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/DocumentExistsOptions.java
+++ b/core/src/main/java/com/arangodb/model/DocumentExistsOptions.java
@@ -24,14 +24,14 @@ package com.arangodb.model;
  * @author Mark Vollmary
  * @author Michele Rastelli
  */
-public final class DocumentExistsOptions {
+public final class DocumentExistsOptions extends TransactionalOptions<DocumentExistsOptions> {
 
     private String ifNoneMatch;
     private String ifMatch;
-    private String streamTransactionId;
 
-    public DocumentExistsOptions() {
-        super();
+    @Override
+    DocumentExistsOptions getThis() {
+        return this;
     }
 
     public String getIfNoneMatch() {
@@ -57,20 +57,6 @@ public final class DocumentExistsOptions {
      */
     public DocumentExistsOptions ifMatch(final String ifMatch) {
         this.ifMatch = ifMatch;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public DocumentExistsOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/DocumentReadOptions.java
+++ b/core/src/main/java/com/arangodb/model/DocumentReadOptions.java
@@ -24,15 +24,15 @@ package com.arangodb.model;
  * @author Mark Vollmary
  * @author Michele Rastelli
  */
-public final class DocumentReadOptions {
+public final class DocumentReadOptions extends TransactionalOptions<DocumentReadOptions> {
 
     private String ifNoneMatch;
     private String ifMatch;
     private Boolean allowDirtyRead;
-    private String streamTransactionId;
 
-    public DocumentReadOptions() {
-        super();
+    @Override
+    DocumentReadOptions getThis() {
+        return this;
     }
 
     public String getIfNoneMatch() {
@@ -75,20 +75,6 @@ public final class DocumentReadOptions {
 
     public Boolean getAllowDirtyRead() {
         return allowDirtyRead;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public DocumentReadOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
-        return this;
     }
 
 }

--- a/core/src/main/java/com/arangodb/model/DocumentReplaceOptions.java
+++ b/core/src/main/java/com/arangodb/model/DocumentReplaceOptions.java
@@ -24,7 +24,7 @@ package com.arangodb.model;
  * @author Mark Vollmary
  * @author Michele Rastelli
  */
-public final class DocumentReplaceOptions {
+public final class DocumentReplaceOptions extends TransactionalOptions<DocumentReplaceOptions> {
 
     private Boolean waitForSync;
     private Boolean ignoreRevs;
@@ -32,12 +32,12 @@ public final class DocumentReplaceOptions {
     private Boolean returnNew;
     private Boolean returnOld;
     private Boolean silent;
-    private String streamTransactionId;
     private Boolean refillIndexCaches;
     private String versionAttribute;
 
-    public DocumentReplaceOptions() {
-        super();
+    @Override
+    DocumentReplaceOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -122,20 +122,6 @@ public final class DocumentReplaceOptions {
      */
     public DocumentReplaceOptions silent(final Boolean silent) {
         this.silent = silent;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public DocumentReplaceOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/DocumentUpdateOptions.java
+++ b/core/src/main/java/com/arangodb/model/DocumentUpdateOptions.java
@@ -24,7 +24,7 @@ package com.arangodb.model;
  * @author Mark Vollmary
  * @author Michele Rastelli
  */
-public final class DocumentUpdateOptions {
+public final class DocumentUpdateOptions extends TransactionalOptions<DocumentUpdateOptions> {
 
     private Boolean keepNull;
     private Boolean mergeObjects;
@@ -34,12 +34,12 @@ public final class DocumentUpdateOptions {
     private Boolean returnNew;
     private Boolean returnOld;
     private Boolean silent;
-    private String streamTransactionId;
     private Boolean refillIndexCaches;
     private String versionAttribute;
 
-    public DocumentUpdateOptions() {
-        super();
+    @Override
+    DocumentUpdateOptions getThis() {
+        return this;
     }
 
     public Boolean getKeepNull() {
@@ -157,20 +157,6 @@ public final class DocumentUpdateOptions {
      */
     public DocumentUpdateOptions silent(final Boolean silent) {
         this.silent = silent;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.0
-     */
-    public DocumentUpdateOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/EdgeCreateOptions.java
+++ b/core/src/main/java/com/arangodb/model/EdgeCreateOptions.java
@@ -23,13 +23,13 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class EdgeCreateOptions {
+public final class EdgeCreateOptions extends TransactionalOptions<EdgeCreateOptions> {
 
     private Boolean waitForSync;
-    private String streamTransactionId;
 
-    public EdgeCreateOptions() {
-        super();
+    @Override
+    EdgeCreateOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -42,20 +42,6 @@ public final class EdgeCreateOptions {
      */
     public EdgeCreateOptions waitForSync(final Boolean waitForSync) {
         this.waitForSync = waitForSync;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public EdgeCreateOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/EdgeDeleteOptions.java
+++ b/core/src/main/java/com/arangodb/model/EdgeDeleteOptions.java
@@ -23,14 +23,14 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class EdgeDeleteOptions {
+public final class EdgeDeleteOptions extends TransactionalOptions<EdgeDeleteOptions> {
 
     private Boolean waitForSync;
     private String ifMatch;
-    private String streamTransactionId;
 
-    public EdgeDeleteOptions() {
-        super();
+    @Override
+    EdgeDeleteOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -56,20 +56,6 @@ public final class EdgeDeleteOptions {
      */
     public EdgeDeleteOptions ifMatch(final String ifMatch) {
         this.ifMatch = ifMatch;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public EdgeDeleteOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/EdgeReplaceOptions.java
+++ b/core/src/main/java/com/arangodb/model/EdgeReplaceOptions.java
@@ -23,14 +23,14 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class EdgeReplaceOptions {
+public final class EdgeReplaceOptions extends TransactionalOptions<EdgeReplaceOptions> {
 
     private Boolean waitForSync;
     private String ifMatch;
-    private String streamTransactionId;
 
-    public EdgeReplaceOptions() {
-        super();
+    @Override
+    EdgeReplaceOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -56,20 +56,6 @@ public final class EdgeReplaceOptions {
      */
     public EdgeReplaceOptions ifMatch(final String ifMatch) {
         this.ifMatch = ifMatch;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public EdgeReplaceOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/EdgeUpdateOptions.java
+++ b/core/src/main/java/com/arangodb/model/EdgeUpdateOptions.java
@@ -23,15 +23,15 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class EdgeUpdateOptions {
+public final class EdgeUpdateOptions extends TransactionalOptions<EdgeUpdateOptions> {
 
     private Boolean keepNull;
     private Boolean waitForSync;
     private String ifMatch;
-    private String streamTransactionId;
 
-    public EdgeUpdateOptions() {
-        super();
+    @Override
+    EdgeUpdateOptions getThis() {
+        return this;
     }
 
     public Boolean getKeepNull() {
@@ -73,20 +73,6 @@ public final class EdgeUpdateOptions {
      */
     public EdgeUpdateOptions ifMatch(final String ifMatch) {
         this.ifMatch = ifMatch;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public EdgeUpdateOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/GraphDocumentReadOptions.java
+++ b/core/src/main/java/com/arangodb/model/GraphDocumentReadOptions.java
@@ -23,15 +23,15 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class GraphDocumentReadOptions {
+public final class GraphDocumentReadOptions extends TransactionalOptions<GraphDocumentReadOptions> {
 
     private String ifNoneMatch;
     private String ifMatch;
     private Boolean allowDirtyRead;
-    private String streamTransactionId;
 
-    public GraphDocumentReadOptions() {
-        super();
+    @Override
+    GraphDocumentReadOptions getThis() {
+        return this;
     }
 
     public String getIfNoneMatch() {
@@ -74,20 +74,6 @@ public final class GraphDocumentReadOptions {
 
     public Boolean getAllowDirtyRead() {
         return allowDirtyRead;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public GraphDocumentReadOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
-        return this;
     }
 
 }

--- a/core/src/main/java/com/arangodb/model/TransactionalOptions.java
+++ b/core/src/main/java/com/arangodb/model/TransactionalOptions.java
@@ -1,0 +1,22 @@
+package com.arangodb.model;
+
+public abstract class TransactionalOptions<T extends TransactionalOptions<T>> {
+
+    abstract T getThis();
+
+    private String streamTransactionId;
+
+    public String getStreamTransactionId() {
+        return streamTransactionId;
+    }
+
+    /**
+     * @param streamTransactionId If set, the operation will be executed within the transaction.
+     * @return options
+     */
+    public T streamTransactionId(final String streamTransactionId) {
+        this.streamTransactionId = streamTransactionId;
+        return getThis();
+    }
+
+}

--- a/core/src/main/java/com/arangodb/model/TransactionalOptions.java
+++ b/core/src/main/java/com/arangodb/model/TransactionalOptions.java
@@ -1,5 +1,8 @@
 package com.arangodb.model;
 
+import com.arangodb.arch.NoRawTypesInspection;
+
+@NoRawTypesInspection
 public abstract class TransactionalOptions<T extends TransactionalOptions<T>> {
 
     abstract T getThis();

--- a/core/src/main/java/com/arangodb/model/VertexCreateOptions.java
+++ b/core/src/main/java/com/arangodb/model/VertexCreateOptions.java
@@ -23,13 +23,13 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class VertexCreateOptions {
+public final class VertexCreateOptions extends TransactionalOptions<VertexCreateOptions> {
 
     private Boolean waitForSync;
-    private String streamTransactionId;
 
-    public VertexCreateOptions() {
-        super();
+    @Override
+    VertexCreateOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -42,20 +42,6 @@ public final class VertexCreateOptions {
      */
     public VertexCreateOptions waitForSync(final Boolean waitForSync) {
         this.waitForSync = waitForSync;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public VertexCreateOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/VertexDeleteOptions.java
+++ b/core/src/main/java/com/arangodb/model/VertexDeleteOptions.java
@@ -23,14 +23,14 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class VertexDeleteOptions {
+public final class VertexDeleteOptions extends TransactionalOptions<VertexDeleteOptions> {
 
     private Boolean waitForSync;
     private String ifMatch;
-    private String streamTransactionId;
 
-    public VertexDeleteOptions() {
-        super();
+    @Override
+    VertexDeleteOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -56,20 +56,6 @@ public final class VertexDeleteOptions {
      */
     public VertexDeleteOptions ifMatch(final String ifMatch) {
         this.ifMatch = ifMatch;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public VertexDeleteOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/VertexReplaceOptions.java
+++ b/core/src/main/java/com/arangodb/model/VertexReplaceOptions.java
@@ -23,14 +23,14 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class VertexReplaceOptions {
+public final class VertexReplaceOptions extends TransactionalOptions<VertexReplaceOptions> {
 
     private Boolean waitForSync;
     private String ifMatch;
-    private String streamTransactionId;
 
-    public VertexReplaceOptions() {
-        super();
+    @Override
+    VertexReplaceOptions getThis() {
+        return this;
     }
 
     public Boolean getWaitForSync() {
@@ -56,20 +56,6 @@ public final class VertexReplaceOptions {
      */
     public VertexReplaceOptions ifMatch(final String ifMatch) {
         this.ifMatch = ifMatch;
-        return this;
-    }
-
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public VertexReplaceOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
         return this;
     }
 

--- a/core/src/main/java/com/arangodb/model/VertexUpdateOptions.java
+++ b/core/src/main/java/com/arangodb/model/VertexUpdateOptions.java
@@ -23,15 +23,15 @@ package com.arangodb.model;
 /**
  * @author Mark Vollmary
  */
-public final class VertexUpdateOptions {
+public final class VertexUpdateOptions extends TransactionalOptions<VertexUpdateOptions> {
 
     private Boolean keepNull;
     private Boolean waitForSync;
     private String ifMatch;
-    private String streamTransactionId;
 
-    public VertexUpdateOptions() {
-        super();
+    @Override
+    VertexUpdateOptions getThis() {
+        return this;
     }
 
     public Boolean getKeepNull() {
@@ -76,17 +76,4 @@ public final class VertexUpdateOptions {
         return this;
     }
 
-    public String getStreamTransactionId() {
-        return streamTransactionId;
-    }
-
-    /**
-     * @param streamTransactionId If set, the operation will be executed within the transaction.
-     * @return options
-     * @since ArangoDB 3.5.1
-     */
-    public VertexUpdateOptions streamTransactionId(final String streamTransactionId) {
-        this.streamTransactionId = streamTransactionId;
-        return this;
-    }
 }

--- a/core/src/main/java/com/arangodb/serde/ArangoSerde.java
+++ b/core/src/main/java/com/arangodb/serde/ArangoSerde.java
@@ -2,6 +2,8 @@ package com.arangodb.serde;
 
 import com.arangodb.ContentType;
 
+import java.util.Objects;
+
 /**
  * Contract for serialization/deserialization of user data.
  * Implementations of this interface could be used for customizing serialization/deserialization of user related data
@@ -32,4 +34,17 @@ public interface ArangoSerde {
      */
     <T> T deserialize(byte[] content, Class<T> clazz);
 
+    /**
+     * Deserializes the content and binds it to the target data type.
+     * For data type {@link ContentType#JSON}, the byte array is the JSON string encoded using the UTF-8 charset.
+     *
+     * @param content byte array to deserialize
+     * @param clazz   class of target data type
+     * @param ctx     serde context
+     * @return deserialized object
+     */
+    default <T> T deserialize(byte[] content, Class<T> clazz, SerdeContext ctx) {
+        Objects.requireNonNull(ctx);
+        return deserialize(content, clazz);
+    }
 }

--- a/core/src/main/java/com/arangodb/serde/ArangoSerde.java
+++ b/core/src/main/java/com/arangodb/serde/ArangoSerde.java
@@ -40,7 +40,7 @@ public interface ArangoSerde {
      *
      * @param content byte array to deserialize
      * @param clazz   class of target data type
-     * @param ctx     serde context
+     * @param ctx     serde context, cannot be null
      * @return deserialized object
      */
     default <T> T deserialize(byte[] content, Class<T> clazz, SerdeContext ctx) {

--- a/core/src/main/java/com/arangodb/serde/SerdeContext.java
+++ b/core/src/main/java/com/arangodb/serde/SerdeContext.java
@@ -1,0 +1,5 @@
+package com.arangodb.serde;
+
+public interface SerdeContext {
+    String getStreamTransactionId();
+}

--- a/core/src/main/java/com/arangodb/serde/SerdeContext.java
+++ b/core/src/main/java/com/arangodb/serde/SerdeContext.java
@@ -1,5 +1,11 @@
 package com.arangodb.serde;
 
+/**
+ * Context holding information about the current request and response.
+ */
 public interface SerdeContext {
+    /**
+     * @return the stream transaction id of the request (if any) or {@code null}
+     */
     String getStreamTransactionId();
 }

--- a/driver/src/test/java/com/arangodb/ArangoCollectionAsyncTest.java
+++ b/driver/src/test/java/com/arangodb/ArangoCollectionAsyncTest.java
@@ -21,6 +21,7 @@
 package com.arangodb;
 
 import com.arangodb.entity.*;
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.internal.serde.SerdeUtils;
 import com.arangodb.model.*;
 import com.arangodb.model.DocumentImportOptions.OnDuplicate;
@@ -557,7 +558,7 @@ class ArangoCollectionAsyncTest extends BaseJunit5 {
         assertThat(createEntity.getRev()).isNotNull();
         assertThat(createEntity.getNew()).isNotNull().isInstanceOf(RawBytes.class);
         Map<String, Object> newDoc = collection.getSerde().deserializeUserData(createEntity.getNew().get(),
-                Map.class);
+                Map.class, SerdeContextImpl.EMPTY);
         assertThat(newDoc).containsAllEntriesOf(doc);
     }
 

--- a/driver/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/driver/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -21,6 +21,7 @@
 package com.arangodb;
 
 import com.arangodb.entity.*;
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.internal.serde.SerdeUtils;
 import com.arangodb.model.*;
 import com.arangodb.model.DocumentImportOptions.OnDuplicate;
@@ -561,7 +562,7 @@ class ArangoCollectionTest extends BaseJunit5 {
         assertThat(createEntity.getRev()).isNotNull();
         assertThat(createEntity.getNew()).isNotNull().isInstanceOf(RawBytes.class);
         Map<String, Object> newDoc = collection.getSerde().deserializeUserData(createEntity.getNew().get(),
-                Map.class);
+                Map.class, SerdeContextImpl.EMPTY);
         assertThat(newDoc).containsAllEntriesOf(doc);
     }
 

--- a/driver/src/test/java/com/arangodb/BaseJunit5.java
+++ b/driver/src/test/java/com/arangodb/BaseJunit5.java
@@ -19,8 +19,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.arangodb.util.TestUtils.TEST_DB;
+
 public class BaseJunit5 {
-    public static final String TEST_DB = "java_driver_test_db";
     protected static final ArangoConfigProperties config = ConfigUtils.loadConfig();
     private static final ArangoDB adb = new ArangoDB.Builder()
             .loadProperties(config)

--- a/driver/src/test/java/com/arangodb/BaseJunit5.java
+++ b/driver/src/test/java/com/arangodb/BaseJunit5.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class BaseJunit5 {
-    private static final String TEST_DB = "java_driver_test_db";
+    public static final String TEST_DB = "java_driver_test_db";
     protected static final ArangoConfigProperties config = ConfigUtils.loadConfig();
     private static final ArangoDB adb = new ArangoDB.Builder()
             .loadProperties(config)

--- a/driver/src/test/java/com/arangodb/JacksonSerdeContextTest.java
+++ b/driver/src/test/java/com/arangodb/JacksonSerdeContextTest.java
@@ -1,0 +1,120 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb;
+
+import com.arangodb.config.ConfigUtils;
+import com.arangodb.entity.BaseDocument;
+import com.arangodb.entity.DocumentCreateEntity;
+import com.arangodb.entity.StreamTransactionEntity;
+import com.arangodb.model.DocumentReadOptions;
+import com.arangodb.model.StreamTransactionOptions;
+import com.arangodb.serde.jackson.JacksonSerde;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Michele Rastelli
+ */
+class JacksonSerdeContextTest {
+
+    private static final String COLLECTION_NAME = "JacksonSerdeContextTest_collection";
+
+    private static ArangoDB arangoDB;
+    private static ArangoDatabase db;
+    private static ArangoCollection collection;
+
+    @BeforeAll
+    static void init() {
+        JacksonSerde serde = JacksonSerde.of(ContentType.JSON)
+                .configure((mapper) -> {
+                    SimpleModule module = new SimpleModule("PersonModule");
+                    module.addDeserializer(Person.class, new PersonDeserializer());
+                    mapper.registerModule(module);
+                });
+        arangoDB = new ArangoDB.Builder()
+                .loadProperties(ConfigUtils.loadConfig())
+                .serde(serde).build();
+
+        db = arangoDB.db(BaseJunit5.TEST_DB);
+        if (!db.exists()) {
+            db.create();
+        }
+
+        collection = db.collection(COLLECTION_NAME);
+        if (!collection.exists()) {
+            collection.create();
+        }
+    }
+
+    @AfterAll
+    static void shutdown() {
+        if (db.exists())
+            db.drop();
+    }
+
+    static class PersonDeserializer extends JsonDeserializer<Person> {
+        @Override
+        public Person deserialize(JsonParser parser, DeserializationContext ctx) throws IOException {
+            JsonNode rootNode = parser.getCodec().readTree(parser);
+            Person person = new Person(rootNode.get("name").asText());
+            person.txId = JacksonSerde.getSerdeContext(ctx).getStreamTransactionId();
+            return person;
+        }
+    }
+
+    static class Person {
+        String name;
+        String txId;
+
+        Person(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    void getDocumentWithinTx() {
+        DocumentCreateEntity<?> doc = collection.insertDocument(
+                new BaseDocument(Collections.singletonMap("name", "foo")), null);
+
+        StreamTransactionEntity tx = db
+                .beginStreamTransaction(new StreamTransactionOptions().readCollections(COLLECTION_NAME));
+
+        Person read = collection.getDocument(doc.getKey(), Person.class,
+                new DocumentReadOptions().streamTransactionId(tx.getId()));
+
+        assertThat(read.name).isEqualTo("foo");
+        assertThat(read.txId).isEqualTo(tx.getId());
+
+        db.abortStreamTransaction(tx.getId());
+    }
+
+}

--- a/driver/src/test/java/com/arangodb/JacksonSerdeContextTest.java
+++ b/driver/src/test/java/com/arangodb/JacksonSerdeContextTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Collections;
 
+import static com.arangodb.util.TestUtils.TEST_DB;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -64,7 +65,7 @@ class JacksonSerdeContextTest {
                 .loadProperties(ConfigUtils.loadConfig())
                 .serde(serde).build();
 
-        db = arangoDB.db(BaseJunit5.TEST_DB);
+        db = arangoDB.db(TEST_DB);
         if (!db.exists()) {
             db.create();
         }

--- a/driver/src/test/java/com/arangodb/SerdeContextTest.java
+++ b/driver/src/test/java/com/arangodb/SerdeContextTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Objects;
 
 import static com.arangodb.util.TestUtils.TEST_DB;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +71,8 @@ class SerdeContextTest {
 
             @Override
             public <T> T deserialize(byte[] content, Class<T> clazz, SerdeContext ctx) {
+                Objects.requireNonNull(ctx);
+
                 if (clazz != Person.class) {
                     throw new UnsupportedOperationException();
                 }

--- a/driver/src/test/java/com/arangodb/SerdeContextTest.java
+++ b/driver/src/test/java/com/arangodb/SerdeContextTest.java
@@ -1,0 +1,133 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb;
+
+import com.arangodb.config.ConfigUtils;
+import com.arangodb.entity.BaseDocument;
+import com.arangodb.entity.DocumentCreateEntity;
+import com.arangodb.entity.StreamTransactionEntity;
+import com.arangodb.model.DocumentReadOptions;
+import com.arangodb.model.StreamTransactionOptions;
+import com.arangodb.serde.ArangoSerde;
+import com.arangodb.serde.SerdeContext;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Michele Rastelli
+ */
+class SerdeContextTest {
+
+    private static final String COLLECTION_NAME = "SerdeContextTest_collection";
+
+    private static ArangoDB arangoDB;
+    private static ArangoDatabase db;
+    private static ArangoCollection collection;
+
+    @BeforeAll
+    static void init() {
+        ArangoSerde serde = new ArangoSerde() {
+            private ObjectMapper mapper = new ObjectMapper()
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+            @Override
+            public byte[] serialize(Object value) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> T deserialize(byte[] content, Class<T> clazz) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> T deserialize(byte[] content, Class<T> clazz, SerdeContext ctx) {
+                if (clazz != Person.class) {
+                    throw new UnsupportedOperationException();
+                }
+
+                try {
+                    Person res = mapper.readValue(content, Person.class);
+                    res.txId = ctx.getStreamTransactionId();
+                    return (T) res;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        arangoDB = new ArangoDB.Builder()
+                .loadProperties(ConfigUtils.loadConfig())
+                .serde(serde).build();
+
+        db = arangoDB.db(BaseJunit5.TEST_DB);
+        if (!db.exists()) {
+            db.create();
+        }
+
+        collection = db.collection(COLLECTION_NAME);
+        if (!collection.exists()) {
+            collection.create();
+        }
+    }
+
+    @AfterAll
+    static void shutdown() {
+        if (db.exists())
+            db.drop();
+    }
+
+    static class Person {
+        String name;
+        String txId;
+
+        Person(@JsonProperty("name") String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    void getDocumentWithinTx() {
+        DocumentCreateEntity<?> doc = collection.insertDocument(
+                new BaseDocument(Collections.singletonMap("name", "foo")), null);
+
+        StreamTransactionEntity tx = db
+                .beginStreamTransaction(new StreamTransactionOptions().readCollections(COLLECTION_NAME));
+
+        Person read = collection.getDocument(doc.getKey(), Person.class,
+                new DocumentReadOptions().streamTransactionId(tx.getId()));
+
+        assertThat(read.name).isEqualTo("foo");
+        assertThat(read.txId).isEqualTo(tx.getId());
+
+        db.abortStreamTransaction(tx.getId());
+    }
+
+}

--- a/driver/src/test/java/com/arangodb/SerdeContextTest.java
+++ b/driver/src/test/java/com/arangodb/SerdeContextTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Collections;
 
+import static com.arangodb.util.TestUtils.TEST_DB;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -87,7 +88,7 @@ class SerdeContextTest {
                 .loadProperties(ConfigUtils.loadConfig())
                 .serde(serde).build();
 
-        db = arangoDB.db(BaseJunit5.TEST_DB);
+        db = arangoDB.db(TEST_DB);
         if (!db.exists()) {
             db.create();
         }

--- a/driver/src/test/java/com/arangodb/StreamTransactionAsyncTest.java
+++ b/driver/src/test/java/com/arangodb/StreamTransactionAsyncTest.java
@@ -470,7 +470,7 @@ class StreamTransactionAsyncTest extends BaseJunit5 {
         // update document from within the tx
         doc.updateAttribute("test", "bar");
         collection
-                .updateDocument(createdDoc.getKey(), doc, new DocumentUpdateOptions().streamTransactionId(tx.getId()));
+                .updateDocument(createdDoc.getKey(), doc, new DocumentUpdateOptions().streamTransactionId(tx.getId())).get();
 
         // assert that the document has not been updated from outside the tx
         assertThat(collection.getDocument(createdDoc.getKey(), BaseDocument.class, null).get()
@@ -478,8 +478,7 @@ class StreamTransactionAsyncTest extends BaseJunit5 {
 
         // assert that the document has been updated from within the tx
         assertThat(collection.getDocument(createdDoc.getKey(), BaseDocument.class,
-                new DocumentReadOptions().streamTransactionId(tx.getId())).get().getProperties()).containsEntry("test", "bar")
-        ;
+                new DocumentReadOptions().streamTransactionId(tx.getId())).get().getProperties()).containsEntry("test", "bar");
 
         db.commitStreamTransaction(tx.getId()).get();
 

--- a/driver/src/test/java/com/arangodb/example/document/GetDocumentExampleTest.java
+++ b/driver/src/test/java/com/arangodb/example/document/GetDocumentExampleTest.java
@@ -22,6 +22,7 @@ package com.arangodb.example.document;
 
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.example.ExampleBase;
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.util.RawBytes;
 import com.arangodb.util.RawJson;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -91,7 +92,7 @@ class GetDocumentExampleTest extends ExampleBase {
     void getAsBytes() {
         final RawBytes doc = collection.getDocument(key, RawBytes.class);
         assertThat(doc.get()).isNotNull();
-        Map<String, Object> mapDoc = collection.getSerde().deserializeUserData(doc.get(), Map.class);
+        Map<String, Object> mapDoc = collection.getSerde().deserializeUserData(doc.get(), Map.class, SerdeContextImpl.EMPTY);
         assertThat(mapDoc).containsEntry("foo", "bar");
     }
 

--- a/driver/src/test/java/com/arangodb/serde/CustomSerdeAsyncTest.java
+++ b/driver/src/test/java/com/arangodb/serde/CustomSerdeAsyncTest.java
@@ -24,6 +24,7 @@ package com.arangodb.serde;
 import com.arangodb.*;
 import com.arangodb.config.ConfigUtils;
 import com.arangodb.internal.serde.InternalSerde;
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.model.DocumentCreateOptions;
 import com.arangodb.serde.jackson.JacksonSerde;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -112,7 +113,7 @@ class CustomSerdeAsyncTest {
         person.name = "Joe";
         InternalSerde serialization = arangoDB.getSerde();
         byte[] serialized = serialization.serializeUserData(person);
-        Person deserializedPerson = serialization.deserializeUserData(serialized, Person.class);
+        Person deserializedPerson = serialization.deserializeUserData(serialized, Person.class, SerdeContextImpl.EMPTY);
         assertThat(deserializedPerson.name).isEqualTo(PERSON_DESERIALIZER_ADDED_PREFIX + PERSON_SERIALIZER_ADDED_PREFIX + person.name);
     }
 
@@ -209,7 +210,7 @@ class CustomSerdeAsyncTest {
     @Test
     void parseNullString() {
         final String json = arangoDB.getSerde().deserializeUserData(arangoDB.getSerde().serializeUserData(null),
-                String.class);
+                String.class, SerdeContextImpl.EMPTY);
         assertThat(json).isNull();
     }
 

--- a/driver/src/test/java/com/arangodb/serde/CustomSerdeTest.java
+++ b/driver/src/test/java/com/arangodb/serde/CustomSerdeTest.java
@@ -24,6 +24,7 @@ package com.arangodb.serde;
 import com.arangodb.*;
 import com.arangodb.config.ConfigUtils;
 import com.arangodb.internal.serde.InternalSerde;
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.model.DocumentCreateOptions;
 import com.arangodb.serde.jackson.JacksonSerde;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -109,7 +110,7 @@ class CustomSerdeTest {
         person.name = "Joe";
         InternalSerde serialization = arangoDB.getSerde();
         byte[] serialized = serialization.serializeUserData(person);
-        Person deserializedPerson = serialization.deserializeUserData(serialized, Person.class);
+        Person deserializedPerson = serialization.deserializeUserData(serialized, Person.class, SerdeContextImpl.EMPTY);
         assertThat(deserializedPerson.name).isEqualTo(PERSON_DESERIALIZER_ADDED_PREFIX + PERSON_SERIALIZER_ADDED_PREFIX + person.name);
     }
 
@@ -206,7 +207,7 @@ class CustomSerdeTest {
     @Test
     void parseNullString() {
         final String json = arangoDB.getSerde().deserializeUserData(arangoDB.getSerde().serializeUserData(null),
-                String.class);
+                String.class, SerdeContextImpl.EMPTY);
         assertThat(json).isNull();
     }
 

--- a/driver/src/test/java/com/arangodb/serde/JacksonConfigurationTest.java
+++ b/driver/src/test/java/com/arangodb/serde/JacksonConfigurationTest.java
@@ -2,6 +2,7 @@ package com.arangodb.serde;
 
 import com.arangodb.ContentType;
 import com.arangodb.internal.serde.InternalSerdeProvider;
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.serde.jackson.JacksonSerde;
 import com.arangodb.util.SlowTest;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,7 +26,7 @@ public class JacksonConfigurationTest {
         }
         String in = sb.toString();
         byte[] bytes = s.serialize(in);
-        String out = s.deserialize(bytes, String.class);
+        String out = s.deserialize(bytes, String.class, SerdeContextImpl.EMPTY);
         assertThat(out).isEqualTo(in);
     }
 

--- a/driver/src/test/java/com/arangodb/serde/SerdeTest.java
+++ b/driver/src/test/java/com/arangodb/serde/SerdeTest.java
@@ -4,6 +4,7 @@ import com.arangodb.ContentType;
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.internal.serde.InternalSerde;
 import com.arangodb.internal.serde.InternalSerdeProvider;
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.internal.serde.SerdeUtils;
 import com.arangodb.util.RawBytes;
 import com.arangodb.util.RawJson;
@@ -28,7 +29,7 @@ class SerdeTest {
         ObjectNode node = JsonNodeFactory.instance.objectNode().put("foo", "bar");
         RawJson raw = RawJson.of(SerdeUtils.INSTANCE.writeJson(node));
         byte[] serialized = s.serialize(raw);
-        RawJson deserialized = s.deserialize(serialized, RawJson.class);
+        RawJson deserialized = s.deserialize(serialized, RawJson.class, SerdeContextImpl.EMPTY);
         assertThat(deserialized).isEqualTo(raw);
     }
 
@@ -39,7 +40,7 @@ class SerdeTest {
         ObjectNode node = JsonNodeFactory.instance.objectNode().put("foo", "bar");
         RawBytes raw = RawBytes.of(s.serialize(node));
         byte[] serialized = s.serialize(raw);
-        RawBytes deserialized = s.deserialize(serialized, RawBytes.class);
+        RawBytes deserialized = s.deserialize(serialized, RawBytes.class, SerdeContextImpl.EMPTY);
         assertThat(deserialized).isEqualTo(raw);
     }
 
@@ -48,7 +49,7 @@ class SerdeTest {
     void deserializeBaseDocumentWithNestedProperties(ContentType type) {
         InternalSerde s = new InternalSerdeProvider(type).create();
         RawJson json = RawJson.of("{\"foo\":\"aaa\",\"properties\":{\"foo\":\"bbb\"}}");
-        BaseDocument deserialized = s.deserialize(s.serialize(json), BaseDocument.class);
+        BaseDocument deserialized = s.deserialize(s.serialize(json), BaseDocument.class, SerdeContextImpl.EMPTY);
         assertThat(deserialized.getAttribute("foo")).isEqualTo("aaa");
         assertThat(deserialized.getAttribute("properties"))
                 .isInstanceOf(Map.class)
@@ -64,7 +65,7 @@ class SerdeTest {
         doc.addAttribute("foo", "aaa");
         doc.addAttribute("properties", Collections.singletonMap("foo", "bbb"));
         byte[] ser = s.serialize(doc);
-        ObjectNode on = s.deserializeUserData(ser, ObjectNode.class);
+        ObjectNode on = s.deserializeUserData(ser, ObjectNode.class, SerdeContextImpl.EMPTY);
         assertThat(on.get("foo").textValue()).isEqualTo("aaa");
         assertThat(on.get("properties").get("foo").textValue()).isEqualTo("bbb");
     }

--- a/driver/src/test/java/com/arangodb/util/TestUtils.java
+++ b/driver/src/test/java/com/arangodb/util/TestUtils.java
@@ -31,7 +31,7 @@ import java.util.UUID;
  * @author Michele Rastelli
  */
 public final class TestUtils {
-
+    public static final String TEST_DB = "java_driver_test_db";
     private static final String[] allChars = TestUtils.generateAllInputChars();
     private static final Random r = new Random();
 

--- a/driver/src/test/resources/META-INF/native-image/reflect-config.json
+++ b/driver/src/test/resources/META-INF/native-image/reflect-config.json
@@ -304,5 +304,11 @@
     "allPublicMethods": true,
     "allDeclaredConstructors": true,
     "allDeclaredClasses": true
+  },
+  {
+    "name": "com.arangodb.SerdeContextTest$Person",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
   }
 ]

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -184,7 +184,11 @@
                             <outputBasedir>${project.build.directory}/generated-test-sources</outputBasedir>
                             <outputDir>replacer</outputDir>
                             <filesToExclude>
-                                **/CustomSerdeTest.**,**/SerdeTest.**,**/SerializableTest.**,**/JacksonInterferenceTest.**
+                                **/CustomSerdeTest.**,
+                                **/SerdeTest.**,
+                                **/SerializableTest.**,
+                                **/JacksonInterferenceTest.**,
+                                **/JacksonSerdeContextTest.**
                             </filesToExclude>
                             <replacements>
                                 <replacement>

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/JacksonSerde.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/JacksonSerde.java
@@ -1,8 +1,11 @@
 package com.arangodb.serde.jackson;
 
 import com.arangodb.ContentType;
+import com.arangodb.internal.serde.SerdeUtils;
 import com.arangodb.serde.ArangoSerde;
+import com.arangodb.serde.SerdeContext;
 import com.arangodb.serde.jackson.internal.JacksonSerdeImpl;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.function.Consumer;
@@ -30,6 +33,16 @@ public interface JacksonSerde extends ArangoSerde {
      */
     static JacksonSerde create(final ObjectMapper mapper) {
         return new JacksonSerdeImpl(mapper);
+    }
+
+    /**
+     * Extracts the {@link SerdeContext} from the current {@link DeserializationContext}.
+     *
+     * @param ctx current Jackson {@link DeserializationContext}
+     * @return current {@link SerdeContext}
+     */
+    static SerdeContext getSerdeContext(DeserializationContext ctx) {
+        return (SerdeContext) ctx.getAttribute(SerdeUtils.SERDE_CONTEXT_ATTRIBUTE_NAME);
     }
 
     /**

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/JacksonSerdeImpl.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/JacksonSerdeImpl.java
@@ -1,12 +1,16 @@
 package com.arangodb.serde.jackson.internal;
 
+import com.arangodb.serde.SerdeContext;
 import com.arangodb.serde.jackson.JacksonSerde;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 
 import java.io.IOException;
 import java.util.function.Consumer;
+
+import static com.arangodb.internal.serde.SerdeUtils.SERDE_CONTEXT_ATTRIBUTE_NAME;
 
 /**
  * Not shaded in arangodb-java-driver-shaded.
@@ -34,6 +38,17 @@ public final class JacksonSerdeImpl implements JacksonSerde {
     public <T> T deserialize(final byte[] content, final Class<T> type) {
         try {
             return mapper.readerFor(mapper.constructType(type)).readValue(content);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> T deserialize(byte[] content, Class<T> type, SerdeContext ctx) {
+        try {
+            return mapper.readerFor(mapper.constructType(type))
+                    .with(ContextAttributes.getEmpty().withPerCallAttribute(SERDE_CONTEXT_ATTRIBUTE_NAME, ctx))
+                    .readValue(content);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/JacksonSerdeImpl.java
+++ b/jackson-serde-json/src/main/java/com/arangodb/serde/jackson/internal/JacksonSerdeImpl.java
@@ -1,5 +1,6 @@
 package com.arangodb.serde.jackson.internal;
 
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.serde.SerdeContext;
 import com.arangodb.serde.jackson.JacksonSerde;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -8,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import static com.arangodb.internal.serde.SerdeUtils.SERDE_CONTEXT_ATTRIBUTE_NAME;
@@ -36,15 +38,12 @@ public final class JacksonSerdeImpl implements JacksonSerde {
 
     @Override
     public <T> T deserialize(final byte[] content, final Class<T> type) {
-        try {
-            return mapper.readerFor(mapper.constructType(type)).readValue(content);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return deserialize(content, type, SerdeContextImpl.EMPTY);
     }
 
     @Override
     public <T> T deserialize(byte[] content, Class<T> type, SerdeContext ctx) {
+        Objects.requireNonNull(ctx);
         try {
             return mapper.readerFor(mapper.constructType(type))
                     .with(ContextAttributes.getEmpty().withPerCallAttribute(SERDE_CONTEXT_ATTRIBUTE_NAME, ctx))

--- a/vst/src/main/java/com/arangodb/vst/internal/VstConnectionAsync.java
+++ b/vst/src/main/java/com/arangodb/vst/internal/VstConnectionAsync.java
@@ -26,8 +26,8 @@ import com.arangodb.internal.InternalRequest;
 import com.arangodb.internal.InternalResponse;
 import com.arangodb.internal.config.ArangoConfig;
 import com.arangodb.internal.serde.InternalSerde;
+import com.arangodb.internal.serde.SerdeContextImpl;
 import com.arangodb.velocypack.VPackSlice;
-import com.arangodb.velocypack.exception.VPackException;
 import com.arangodb.velocypack.exception.VPackParserException;
 import com.arangodb.vst.internal.utils.CompletableFutureUtils;
 import org.slf4j.Logger;
@@ -94,7 +94,7 @@ public class VstConnectionAsync extends VstConnection<CompletableFuture<Message>
                     final InternalResponse response;
                     try {
                         response = createResponse(m);
-                    } catch (final VPackParserException e) {
+                    } catch (final Exception e) {
                         rfuture.completeExceptionally(e);
                         return;
                     }
@@ -104,7 +104,7 @@ public class VstConnectionAsync extends VstConnection<CompletableFuture<Message>
                     rfuture.completeExceptionally(e);
                 }
             });
-        } catch (final VPackException e) {
+        } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             rfuture.completeExceptionally(e);
         }
@@ -152,7 +152,7 @@ public class VstConnectionAsync extends VstConnection<CompletableFuture<Message>
     }
 
     private InternalResponse createResponse(final Message message) throws VPackParserException {
-        final InternalResponse response = serde.deserialize(message.getHead().toByteArray(), InternalResponse.class);
+        InternalResponse response = serde.deserialize(message.getHead().toByteArray(), InternalResponse.class, SerdeContextImpl.EMPTY);
         if (message.getBody() != null) {
             response.setBody(message.getBody().toByteArray());
         }


### PR DESCRIPTION
This PR adds a new (optional) method to `ArangoSerde` which accepts an additional deserialization context as parameter. In the current implementation, the deserialization context contains only the stream transaction id of the request.

Furthermore, all request options classes with stream transaction id property implement now a new interface `TransactionalOptions`.
 