### PR TITLE
Improve serialization and deserialization performances of RawData

### DIFF
--- a/core/src/main/java/com/arangodb/internal/serde/InternalDeserializers.java
+++ b/core/src/main/java/com/arangodb/internal/serde/InternalDeserializers.java
@@ -6,10 +6,8 @@ import com.arangodb.entity.InvertedIndexPrimarySort;
 import com.arangodb.entity.ReplicationFactor;
 import com.arangodb.entity.arangosearch.CollectionLink;
 import com.arangodb.entity.arangosearch.FieldLink;
-import com.arangodb.util.RawBytes;
 import com.arangodb.util.RawJson;
 import com.arangodb.internal.InternalResponse;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -17,7 +15,6 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.*;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,20 +26,7 @@ public final class InternalDeserializers {
     static final JsonDeserializer<RawJson> RAW_JSON_DESERIALIZER = new JsonDeserializer<RawJson>() {
         @Override
         public RawJson deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            // TODO: find a way to access raw bytes directly
             return RawJson.of(SerdeUtils.INSTANCE.writeJson(p.readValueAsTree()));
-        }
-    };
-
-    static final JsonDeserializer<RawBytes> RAW_BYTES_DESERIALIZER = new JsonDeserializer<RawBytes>() {
-        @Override
-        public RawBytes deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            // TODO: find a way to access raw bytes directly
-            ByteArrayOutputStream os = new ByteArrayOutputStream();
-            try (JsonGenerator g = p.getCodec().getFactory().createGenerator(os)) {
-                g.writeTree(p.readValueAsTree());
-            }
-            return RawBytes.of(os.toByteArray());
         }
     };
 

--- a/core/src/main/java/com/arangodb/internal/serde/InternalModule.java
+++ b/core/src/main/java/com/arangodb/internal/serde/InternalModule.java
@@ -4,7 +4,6 @@ import com.arangodb.entity.CollectionStatus;
 import com.arangodb.entity.CollectionType;
 import com.arangodb.entity.InvertedIndexPrimarySort;
 import com.arangodb.entity.ReplicationFactor;
-import com.arangodb.util.RawBytes;
 import com.arangodb.util.RawJson;
 import com.arangodb.internal.InternalRequest;
 import com.arangodb.internal.InternalResponse;
@@ -22,12 +21,10 @@ enum InternalModule implements Supplier<Module> {
         module = new SimpleModule();
 
         module.addSerializer(RawJson.class, InternalSerializers.RAW_JSON_SERIALIZER);
-        module.addSerializer(RawBytes.class, InternalSerializers.RAW_BYTES_SERIALIZER);
         module.addSerializer(InternalRequest.class, InternalSerializers.REQUEST);
         module.addSerializer(CollectionType.class, InternalSerializers.COLLECTION_TYPE);
 
         module.addDeserializer(RawJson.class, InternalDeserializers.RAW_JSON_DESERIALIZER);
-        module.addDeserializer(RawBytes.class, InternalDeserializers.RAW_BYTES_DESERIALIZER);
         module.addDeserializer(CollectionStatus.class, InternalDeserializers.COLLECTION_STATUS);
         module.addDeserializer(CollectionType.class, InternalDeserializers.COLLECTION_TYPE);
         module.addDeserializer(ReplicationFactor.class, InternalDeserializers.REPLICATION_FACTOR);

--- a/core/src/main/java/com/arangodb/internal/serde/InternalSerializers.java
+++ b/core/src/main/java/com/arangodb/internal/serde/InternalSerializers.java
@@ -4,11 +4,9 @@ import com.arangodb.entity.CollectionType;
 import com.arangodb.entity.arangosearch.CollectionLink;
 import com.arangodb.entity.arangosearch.FieldLink;
 import com.arangodb.internal.ArangoRequestParam;
-import com.arangodb.util.RawBytes;
 import com.arangodb.util.RawJson;
 import com.arangodb.internal.InternalRequest;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
@@ -24,16 +22,6 @@ public final class InternalSerializers {
         @Override
         public void serialize(RawJson value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
             gen.writeTree(SerdeUtils.INSTANCE.parseJson(value.get()));
-        }
-    };
-    static final JsonSerializer<RawBytes> RAW_BYTES_SERIALIZER = new JsonSerializer<RawBytes>() {
-        @Override
-        public void serialize(RawBytes value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-            // TODO: find a way to append raw bytes directly
-            // see https://github.com/FasterXML/jackson-core/issues/914
-            try (JsonParser parser = gen.getCodec().getFactory().createParser(value.get())) {
-                gen.writeTree(parser.readValueAsTree());
-            }
         }
     };
     static final JsonSerializer<InternalRequest> REQUEST = new JsonSerializer<InternalRequest>() {

--- a/test-functional/src/test/java/com/arangodb/serde/SerdeTest.java
+++ b/test-functional/src/test/java/com/arangodb/serde/SerdeTest.java
@@ -37,8 +37,8 @@ class SerdeTest {
         InternalSerde s = new InternalSerdeProvider(type).create();
         ObjectNode node = JsonNodeFactory.instance.objectNode().put("foo", "bar");
         RawBytes raw = RawBytes.of(s.serialize(node));
-        byte[] serialized = s.serialize(raw);
-        RawBytes deserialized = s.deserialize(serialized, RawBytes.class);
+        byte[] serialized = s.serializeUserData(raw);
+        RawBytes deserialized = s.deserializeUserData(serialized, RawBytes.class);
         assertThat(deserialized).isEqualTo(raw);
     }
 


### PR DESCRIPTION
Serialization and deserialization of `RawBytes` can directly return the bytes without parsing them as Json tree and then serializing them again.

This is also true for `RawJson`, if the data format of the serde is JSON.